### PR TITLE
Generate Maven pom.xml files

### DIFF
--- a/.bach/src/build/build/Build.java
+++ b/.bach/src/build/build/Build.java
@@ -4,16 +4,15 @@ import de.sormuras.bach.Bach;
 import de.sormuras.bach.Configuration;
 import de.sormuras.bach.Flag;
 import de.sormuras.bach.Project;
+import de.sormuras.bach.action.GenerateMavenPomFiles;
+import de.sormuras.bach.project.CodeUnit;
 import de.sormuras.bach.project.Feature;
 import java.lang.System.Logger.Level;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 
 /** purejin's build program. */
 class Build {
 
-  public static void main(String... args) throws Exception {
+  public static void main(String... args) {
     var version = "19.1-ea";
 
     var silk =
@@ -54,8 +53,21 @@ class Build {
     new Bach(configuration, silk).build(bach -> {
       bach.deleteClassesDirectories();
       bach.executeDefaultBuildActions();
+      new GeneratePoms(bach).execute();
     });
 
+  }
+
+  static class GeneratePoms extends GenerateMavenPomFiles {
+
+    public GeneratePoms(Bach bach) {
+      super(bach, "    ");
+    }
+
+    @Override
+    public String computeMavenGroupId(CodeUnit unit) {
+      return "se.jbee.inject";
+    }
   }
 
 }

--- a/.github/workflows/bach.yml
+++ b/.github/workflows/bach.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 'Emit version of JShell (trigger creation of user''s preferences directory)'
         run: jshell --version
       - name: 'Build with Bach.java'
-        run: jshell https://sormuras.de/bach@11.7/build
+        run: jshell https://sormuras.de/bach/build
       - name: 'Upload build artifact'
         uses: actions/upload-artifact@v2
         with:

--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -5,12 +5,5 @@ before_install:
 
 install:
   - unset JAVA_TOOL_OPTIONS
-  - jshell https://sormuras.de/bach@11.7/build
-  - VERSION="19.1-ea"
-  - MODULE_AND_VERSION="se.jbee.inject@${VERSION}"
-  - OUT=".bach/workspace"
-  - POM_FILE="-DpomFile=${OUT}/${MODULE_AND_VERSION}.pom.xml"
-  - JAR_FILE="-Dfile=${OUT}/modules/${MODULE_AND_VERSION}.jar"
-  - SRC_FILE="-Dsources=${OUT}/sources/${MODULE_AND_VERSION}-sources.jar"
-  - API_FILE="-Djavadoc=${OUT}/documentation/purejin@${VERSION}-api.jar"
-  - mvn --batch-mode --no-transfer-progress install:install-file ${POM_FILE} ${JAR_FILE} ${SRC_FILE} ${API_FILE}
+  - jshell https://sormuras.de/bach/build
+  - for files in .bach/workspace/deploy/maven/*.files ; do mvn --batch-mode --no-transfer-progress install:install-file $(cat ${files}) ; done


### PR DESCRIPTION
- Upgrade Bach to "latest-and-greatest" SNAPSHOT version (`11.8-ea`)
- Generate consumer `pom.xml` for each Java module declared by purejin
- Let JitPack find and install all of 'em