### PR TITLE
Hints in Strategies

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -12,7 +12,6 @@
       <option name="INDENT_CASE_FROM_SWITCH" value="false" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
-      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
       <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
       <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
       <option name="CALL_PARAMETERS_WRAP" value="1" />

--- a/se.jbee.inject.action/main/java/se/jbee/inject/action/Executor.java
+++ b/se.jbee.inject.action/main/java/se/jbee/inject/action/Executor.java
@@ -1,20 +1,20 @@
 /*
  *  Copyright (c) 2012-2019, Jan Bernitt
- *	
+ *
  *  Licensed under the Apache License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0
  */
 package se.jbee.inject.action;
 
-import java.lang.reflect.Method;
-
 import se.jbee.inject.UnresolvableDependency.SupplyFailed;
+
+import java.lang.reflect.Method;
 
 /**
  * The {@link Executor} invokes the actual action {@link Method}. It is an
  * abstraction for the inner mechanics of {@link Action}s so that these can be
  * customised by replacing the {@link Executor} by making a bind (see
  * {@link ActionModule}).
- * 
+ *
  * @see Action
  */
 @FunctionalInterface
@@ -22,7 +22,7 @@ public interface Executor {
 
 	/**
 	 * Runs an {@link Action} by invoking the underlying method.
-	 * 
+	 *
 	 * @param args all resolved arguments for the method (in order)
 	 * @param value provided (also one of the arguments)
 	 * @throws ActionExecutionFailed in case of any {@link Exception} during

--- a/se.jbee.inject.api/main/java/se/jbee/inject/AnnotatedWith.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/AnnotatedWith.java
@@ -1,5 +1,8 @@
 package se.jbee.inject;
 
+import se.jbee.inject.Annotated.Enhancer;
+import se.jbee.inject.lang.Type;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
@@ -7,9 +10,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.Supplier;
-
-import se.jbee.inject.Annotated.Enhancer;
-import se.jbee.inject.lang.Type;
 
 /**
  * Allows to resolve bound instances annotated with a certain {@link Annotation}

--- a/se.jbee.inject.api/main/java/se/jbee/inject/DeclarationType.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/DeclarationType.java
@@ -50,11 +50,11 @@ public enum DeclarationType implements Qualifying<DeclarationType> {
 	PROVIDED,
 
 	/**
-	 * A auto-bind has been used. That is binding a class or instance to the
+	 * A super-bind has been used. That is binding a class or instance to the
 	 * exact type as {@link #EXPLICIT} and to all its super-classes and
 	 * -interfaces as a AUTO bound bind.
 	 */
-	AUTO,
+	SUPER,
 
 	/**
 	 * A bind that is meant to co-exist with others that might have the same
@@ -100,7 +100,7 @@ public enum DeclarationType implements Qualifying<DeclarationType> {
 	 *         false
 	 */
 	public boolean droppedWith(DeclarationType other) {
-		return this == other && (this == AUTO || this == PROVIDED);
+		return this == other && (this == SUPER || this == PROVIDED);
 	}
 
 }

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Dependency.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Dependency.java
@@ -82,7 +82,7 @@ public final class Dependency<T>
 		StringBuilder b = new StringBuilder();
 		b.append(instance);
 		for (int i = hierarchy.length - 1; i >= 0; i--)
-			b.append(" :: ").append(hierarchy[i].target);
+			b.append(" <= ").append(hierarchy[i].target);
 		return b.toString();
 	}
 
@@ -134,7 +134,11 @@ public final class Dependency<T>
 	public Instance<?> target(int level) {
 		return level >= hierarchy.length
 			? Instance.ANY
-			: hierarchy[hierarchy.length - 1 - level].target.instance;
+			: injection(level).target.instance;
+	}
+
+	public Injection injection(int level) {
+		return hierarchy[hierarchy.length - 1 - level];
 	}
 
 	public int injectionDepth() {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Env.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Env.java
@@ -51,6 +51,8 @@ public interface Env {
 	 */
 	String GP_USE_VERIFICATION = "verify";
 
+	String GP_BIND_BINDINGS = "self-bind";
+
 	<T> T property(Name qualifier, Type<T> property, Package ns)
 			throws InconsistentDeclaration;
 

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Extends.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Extends.java
@@ -1,12 +1,12 @@
 package se.jbee.inject;
 
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.ServiceLoader;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * {@link Annotation} used in connection with {@link ServiceLoader} mechanism to

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
@@ -10,8 +10,8 @@ import se.jbee.inject.lang.Typed;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
-import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 
 import static se.jbee.inject.Instance.anyOf;
@@ -33,6 +33,13 @@ public final class Hint<T> implements Typed<T> {
 
 	public static Hint<?>[] none() {
 		return NO_PARAMS;
+	}
+
+	public static Hint<?>[] signature(Class<?> ... parameterTypes) {
+		if (parameterTypes.length == 0)
+			return none();
+		return Arrays.stream(parameterTypes).map(
+				Hint::relativeReferenceTo).toArray(Hint[]::new);
 	}
 
 	public static <T> Hint<T> relativeReferenceTo(Class<T> target) {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
@@ -143,10 +143,15 @@ public final class Hint<T> implements Typed<T> {
 
 	/**
 	 * @return a more qualified {@link Hint} if the provided type is more
-	 * qualified
+	 * qualified which changes the references but does not change {@link #asType}
+	 * in case that was intentionally set to a supertype.
+	 *
+	 * At the point this method is called the {@link #asType} already had its
+	 * effect but we still want to preserve the information for debugging so
+	 * we do not get confused.
 	 */
 	private Hint<?> parameterized(Type<?> type) {
-		return type.moreQualifiedThan(asType) ? typed(type) : this;
+		return type.moreQualifiedThan(asType) ? typed(type).asType(asType) : this;
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
@@ -93,7 +93,21 @@ public final class Hint<T> implements Typed<T> {
 		return new Hint<>(asType, null, null, null);
 	}
 
-	public static boolean matches(Executable member, Hint<?>[] hints) {
+	public static boolean matchesInOrder(Executable member, Hint<?>[] hints) {
+		if (hints.length == 0)
+			return true;
+		Type<?>[] types = parameterTypes(member);
+		int i = 0;
+		for (Hint<?> hint : hints) {
+			while (i < types.length && !hint.asType.isAssignableTo(types[i]))
+				i++;
+			if (i >= types.length)
+				return false;
+		}
+		return true;
+	}
+
+	public static boolean matchesInRandomOrder(Executable member, Hint<?>[] hints) {
 		if (hints.length == 0)
 			return true;
 		Type<?>[] types = parameterTypes(member);
@@ -103,7 +117,7 @@ public final class Hint<T> implements Typed<T> {
 			while (!matched && i < types.length) {
 				Type<?> type = types[i];
 				if (type != null && hint.asType.isAssignableTo(type)) {
-					types[i] = null;
+					types[i] = null; // nark as handled by removing it
 					matched = true;
 				}
 				i++;

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Hint.java
@@ -9,11 +9,14 @@ import se.jbee.inject.lang.Type;
 import se.jbee.inject.lang.Typed;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.Map;
 
 import static se.jbee.inject.Instance.anyOf;
 import static se.jbee.inject.Instance.instance;
+import static se.jbee.inject.lang.Type.parameterTypes;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -81,6 +84,27 @@ public final class Hint<T> implements Typed<T> {
 
 	public static <T> Hint<T> constantNull(Type<T> asType) {
 		return new Hint<>(asType, null, null, null);
+	}
+
+	public static boolean matches(Executable member, Hint<?>[] hints) {
+		if (hints.length == 0)
+			return true;
+		Type<?>[] types = parameterTypes(member);
+		for (Hint<?> hint : hints) {
+			boolean matched = false;
+			int i = 0;
+			while (!matched && i < types.length) {
+				Type<?> type = types[i];
+				if (type != null && hint.asType.isAssignableTo(type)) {
+					types[i] = null;
+					matched = true;
+				}
+				i++;
+			}
+			if (!matched)
+				return false;
+		}
+		return true;
 	}
 
 	public static Hint<?>[] match(Type<?>[] types, Hint<?>... hints) {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Injection.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Injection.java
@@ -44,7 +44,7 @@ public final class Injection implements Serializable {
 
 	@Override
 	public String toString() {
-		return dependency + " for " + target + " ?";
+		return dependency + " from " + target;
 	}
 
 	public Injection ignoredScoping() {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Instance.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Instance.java
@@ -9,9 +9,9 @@ import se.jbee.inject.lang.Qualifying;
 import se.jbee.inject.lang.Type;
 import se.jbee.inject.lang.Typed;
 
-import static se.jbee.inject.lang.Type.raw;
-
 import java.io.Serializable;
+
+import static se.jbee.inject.lang.Type.raw;
 
 /**
  * Used to tell that we don#t want just one singleton at a time but multiple

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Instance.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Instance.java
@@ -84,7 +84,7 @@ public final class Instance<T> implements Typed<T>, Qualifying<Instance<?>>,
 
 	@Override
 	public String toString() {
-		return type.toString() + (name.isAny() ? "" : " " + name);
+		return type.toString() + (name.isDefault() ? "" : " " + name);
 	}
 
 	public boolean isAny() {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Instance.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Instance.java
@@ -84,7 +84,7 @@ public final class Instance<T> implements Typed<T>, Qualifying<Instance<?>>,
 
 	@Override
 	public String toString() {
-		return type.toString() + " " + name;
+		return type.toString() + (name.isAny() ? "" : " " + name);
 	}
 
 	public boolean isAny() {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Instances.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Instances.java
@@ -70,7 +70,7 @@ public final class Instances implements Qualifying<Instances>,
 		StringBuilder b = new StringBuilder();
 		for (int i = 0; i < hierarchy.length; i++) {
 			if (i > 0)
-				b.append(" => ");
+				b.append(" within ");
 			b.append(hierarchy[i]);
 		}
 		return b.toString();

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Instances.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Instances.java
@@ -7,13 +7,13 @@ package se.jbee.inject;
 
 import se.jbee.inject.lang.Qualifying;
 
-import static java.util.Arrays.asList;
-import static se.jbee.inject.lang.Utils.arrayCompare;
-import static se.jbee.inject.lang.Utils.arrayPrepend;
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
+
+import static java.util.Arrays.asList;
+import static se.jbee.inject.lang.Utils.arrayCompare;
+import static se.jbee.inject.lang.Utils.arrayPrepend;
 
 /**
  * A hierarchy of {@link Instance}s.

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Locator.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Locator.java
@@ -9,10 +9,10 @@ import se.jbee.inject.lang.Qualifying;
 import se.jbee.inject.lang.Type;
 import se.jbee.inject.lang.Typed;
 
+import java.io.Serializable;
+
 import static se.jbee.inject.Dependency.dependency;
 import static se.jbee.inject.lang.Type.raw;
-
-import java.io.Serializable;
 
 /**
  * Describes WHAT (type-wise) can be injected and WHERE it can be injected.

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Name.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Name.java
@@ -13,8 +13,6 @@ import java.io.Serializable;
 /**
  * A {@link Name} is used as discriminator in cases where multiple
  * {@link Instance}s are bound for the same {@link Type}.
- *
- * @author Jan Bernitt (jan@jbee.se)
  */
 public final class Name
 		implements Qualifying<Name>, Serializable, Comparable<Name> {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Packages.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Packages.java
@@ -8,16 +8,12 @@ package se.jbee.inject;
 import se.jbee.inject.lang.Qualifying;
 import se.jbee.inject.lang.Type;
 
-import static java.util.Arrays.asList;
-import static se.jbee.inject.lang.Utils.arrayCompare;
-import static se.jbee.inject.lang.Utils.arrayContains;
-import static se.jbee.inject.lang.Utils.arrayMap;
-import static se.jbee.inject.lang.Utils.seqCount;
-import static se.jbee.inject.lang.Utils.seqRegionEquals;
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+
+import static java.util.Arrays.asList;
+import static se.jbee.inject.lang.Utils.*;
 
 /**
  * A set of {@link Package}s described one or more root packages (on the same

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Resource.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Resource.java
@@ -10,6 +10,7 @@ import se.jbee.inject.lang.Type;
 
 import java.util.function.Function;
 
+import static se.jbee.inject.DeclarationType.IMPLICIT;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -153,18 +154,25 @@ public final class Resource<T> implements Comparable<Resource<?>>,
 
 	@Override
 	public int compareTo(Resource<?> other) {
-		Locator<?> l1 = signature;
-		Locator<?> l2 = other.signature;
-		Class<?> c1 = l1.type().rawType;
-		Class<?> c2 = l2.type().rawType;
-		if (c1 != c2) {
-			if (c1.isAssignableFrom(c2))
+		Locator<?> a = signature;
+		Locator<?> b = other.signature;
+		Class<?> aRaw = a.type().rawType;
+		Class<?> bRaw = b.type().rawType;
+		// first of all we must sort by raw type
+		if (aRaw != bRaw) {
+			if (aRaw.isAssignableFrom(bRaw))
 				return 1;
-			if (c2.isAssignableFrom(c1))
+			if (bRaw.isAssignableFrom(aRaw))
 				return -1;
-			return c1.getName().compareTo(c2.getName());
+			return aRaw.getName().compareTo(bRaw.getName());
 		}
-		return Qualifying.compare(l1, l2);
+		// secondly any implicit bind is always after any other type of bind
+		if (source.declarationType == IMPLICIT && other.source.declarationType != IMPLICIT)
+			return 1;
+		if (source.declarationType != IMPLICIT && other.source.declarationType == IMPLICIT)
+			return -1;
+		// for same type and non implicit (or both implicit) binds compare their Locator
+		return Qualifying.compare(a, b);
 	}
 
 	@Override

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Source.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Source.java
@@ -41,7 +41,7 @@ public final class Source
 	@Override
 	public String toString() {
 		return ident.getSimpleName() + "#" + declarationNo
-			+ declarationType.name().charAt(0);
+			+ ":" + declarationType.name().charAt(0);
 	}
 
 	@Override

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Supplier.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Supplier.java
@@ -7,7 +7,20 @@ package se.jbee.inject;
 
 /**
  * A {@link Supplier} is a source or factory for specific instances within the
- * given {@link Injector} context.
+ * given {@link Injector} context. It can be understood as the "backend"
+ * abstraction that actually does the work within the internals of the {@link
+ * Injector} implementation.
+ * <p>
+ * The {@link Supplier} declared in binding phase is later used in the form of
+ * the {@link Provider} passed to the {@link Scope#provide(int, int, Dependency,
+ * Provider)} method. Therefore using a {@link Supplier} creates instances
+ * within a {@link Scope}.
+ * <p>
+ * This is in contrast to the {@link Generator} abstraction that is the
+ * "frontend" or user facing abstraction to create or yield instances. Normally
+ * a {@link Generator} is just a facade to reach down to the {@link Supplier}
+ * backing it but it can also be an implementation that is not backed by a
+ * {@link Supplier} which then means it also does not apply any {@link Scope}ing.
  *
  * @param <T> The type of the instance being resolved
  */
@@ -62,7 +75,7 @@ public interface Supplier<T> {
 	 * used each time an instance is needed.
 	 */
 	static <T> Supplier<T> nonScopedBy(Generator<T> generator) {
-		/**
+		/*
 		 * This cannot be changed to a lambda since we need a type that actually
 		 * implements both {@link Supplier} and {@link Generator}. This way the
 		 * {@link Generator} is picked directly by the {@link Injector}.

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Target.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Target.java
@@ -149,9 +149,18 @@ public final class Target
 
 	@Override
 	public String toString() {
-		String symbolic = instance.isAny() ? "*" : instance.toString();
-		return (indirect ? "!" : "") + " in " + packages + " into "
-				+ parents + " => " + symbolic + " ";
+		StringBuilder str = new StringBuilder();
+		if (indirect)
+			str.append("!");
+		if (!packages.includesAll())
+			str.append(" in package " + packages);
+		if (!parents.isAny() || !instance.isAny()) {
+			str.append(" when injecting ");
+			str.append(instance.isAny() ? "*" : instance.toString());
+			if (!parents.isAny())
+				str.append( " into " + parents);
+		}
+		return str.toString();
 	}
 
 	public Target inPackageAndSubPackagesOf(Class<?> type) {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Bind.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Bind.java
@@ -1,19 +1,11 @@
 /*
  *  Copyright (c) 2012-2019, Jan Bernitt
- *	
+ *
  *  Licensed under the Apache License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0
  */
 package se.jbee.inject.bind;
 
-import se.jbee.inject.DeclarationType;
-import se.jbee.inject.Env;
-import se.jbee.inject.Instance;
-import se.jbee.inject.Locator;
-import se.jbee.inject.Name;
-import se.jbee.inject.Scope;
-import se.jbee.inject.Source;
-import se.jbee.inject.Supplier;
-import se.jbee.inject.Target;
+import se.jbee.inject.*;
 import se.jbee.inject.config.ScopesBy;
 
 /**
@@ -102,10 +94,9 @@ public final class Bind {
 	}
 
 	private <T> Name effectiveScope(Locator<T> locator) {
-		Name effectiveScope = scope.equalTo(Scope.mirror)
-			? env.property(ScopesBy.class, source.pkg()).reflect(
-					locator.type().rawType)
-			: scope;
+		Name effectiveScope = scope.equalTo(Scope.mirror) //
+				? env.property(ScopesBy.class, source.pkg()).reflect(locator.type().rawType)
+				: scope;
 		return effectiveScope.equalTo(Scope.auto)
 			? Scope.application
 			: effectiveScope;

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Bind.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Bind.java
@@ -37,8 +37,8 @@ public final class Bind {
 		return as(DeclarationType.MULTI);
 	}
 
-	public Bind asAuto() {
-		return as(DeclarationType.AUTO);
+	public Bind asSuper() {
+		return as(DeclarationType.SUPER);
 	}
 
 	public Bind asImplicit() {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/BindingConsolidation.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/BindingConsolidation.java
@@ -1,0 +1,53 @@
+package se.jbee.inject.bind;
+
+import se.jbee.inject.*;
+
+/**
+ * {@link BindingConsolidation} is the process of verifying the consistency of a
+ * given set of {@link Binding}s, remove those {@link Binding}s that clash but
+ * were not explicitly made and sort the {@link Binding}s in an order that
+ * groups them by {@link se.jbee.inject.Supplier#supply(Dependency, Injector)}
+ * return type and from the most qualified to the lest qualified within each
+ * type group.
+ * <p>
+ * This process should occur once  all {@link Binding}s have been expanded from
+ * the declaration {@link Bundle}s and {@link Module}s.
+ *
+ * @see DeclarationType for more details
+ * @since 8.1
+ */
+public interface BindingConsolidation {
+
+	/**
+	 * Returns the consolidated, that means sorted and disambiguated list of
+	 * {@link Binding}s.
+	 * <p>
+	 * If the input does not allow to determine such a list it fails throwing an
+	 * {@link InconsistentBinding} exception.
+	 * <p>
+	 * If {@link Binding}s of type {@link BindingType#REQUIRED} were made that
+	 * are not satisfied by any of the bindings in the given set a {@link
+	 * se.jbee.inject.UnresolvableDependency} exception is thrown.
+	 *
+	 * @param env      The configuration to use to read properties that
+	 *                 customise the consolidation process.
+	 * @param declared the set of {@link Binding}s that was the output of the
+	 *                 {@link Bundle} and {@link Module} expansion (or whatever
+	 *                 source was used). These represent a bag, that means no
+	 *                 particular order is required and duplicates are
+	 *                 permitted.
+	 * @return a list containing the elements of the provided set after that has
+	 * been disambiguated and sorted. This may or may not be the provided set
+	 * itself if appropriate. This may or may not sort the provided set in place
+	 * or return a new array.
+	 * @throws InconsistentBinding    when bindings in the provided set were
+	 *                                ambiguous but explicitly defined
+	 * @throws UnresolvableDependency when a required binding wasn't satisfied
+	 *                                by any of the other bindings in the set
+	 *                                (after it had been disambiguated). This
+	 *                                can mean there were matching bindings in
+	 *                                the set but they were ambiguous and not
+	 *                                explicit so all of them got removed.
+	 */
+	Binding<?>[] consolidate(Env env, Binding<?>[] declared);
+}

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Bindings.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Bindings.java
@@ -5,8 +5,8 @@
  */
 package se.jbee.inject.bind;
 
-import se.jbee.inject.*;
 import se.jbee.inject.Annotated.Enhancer;
+import se.jbee.inject.*;
 import se.jbee.inject.lang.Type;
 
 import java.lang.annotation.Annotation;
@@ -20,7 +20,7 @@ import static se.jbee.inject.Name.named;
 import static se.jbee.inject.lang.Type.classType;
 import static se.jbee.inject.lang.Type.raw;
 import static se.jbee.inject.lang.Utils.arrayOf;
-import static se.jbee.inject.lang.Utils.isClassMonomodal;
+import static se.jbee.inject.lang.Utils.isClassConceptStateless;
 
 /**
  * {@link Bindings} accumulate the {@link Binding} during the bootstrapping.
@@ -136,7 +136,7 @@ public final class Bindings {
 		for (Module m : modules) {
 			Class<? extends Module> ns = m.getClass();
 			final boolean hasBeenDeclared = declared.contains(ns);
-			if (hasBeenDeclared && !isClassMonomodal(ns))
+			if (hasBeenDeclared && !isClassConceptStateless(ns))
 				multimodals.add(ns);
 			if (!hasBeenDeclared || multimodals.contains(ns)) {
 				m.declare(this, env);

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/InconsistentBinding.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/InconsistentBinding.java
@@ -59,7 +59,7 @@ public final class InconsistentBinding extends InconsistentDeclaration {
 					+ b);
 	}
 
-	public static InconsistentBinding loop(Binding<?> inconsistent,
+	public static InconsistentBinding referenceLoop(Binding<?> inconsistent,
 			Instance<?> linked, Instance<?> bound) {
 		return new InconsistentBinding(
 				"Detected a self-referential binding: \n\t" + bound + " => "

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/InconsistentBinding.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/InconsistentBinding.java
@@ -42,7 +42,7 @@ public final class InconsistentBinding extends InconsistentDeclaration {
 	public static InconsistentBinding undefinedEnvProperty(Name name,
 			Type<?> property, Package scope) {
 		return new InconsistentBinding(
-				"Attempt to resolve environment property failed, no value was bound to "
+				"Missing environment property: "
 					+ name + " of type " + property + " in " + scope);
 	}
 

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/ValueBinder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/ValueBinder.java
@@ -5,13 +5,13 @@
  */
 package se.jbee.inject.bind;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-
 import se.jbee.inject.Env;
 import se.jbee.inject.Instance;
 import se.jbee.inject.Locator;
 import se.jbee.inject.Supplier;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 
 /**
  * A {@linkplain ValueBinder} is a pure function that transforms a source value

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
@@ -911,8 +911,8 @@ public class Binder {
 		}
 
 		protected final void expand(Object value) {
-			declareBindingsIn(bind().asType(locator, BindingType.VALUE, null),
-					value);
+			declareBindingsIn(bind() //
+					.asType(locator, BindingType.VALUE, null), value);
 		}
 
 		protected final void expand(BindingType type,
@@ -1011,14 +1011,14 @@ public class Binder {
 		}
 
 		public void toConstructor() {
-			to(env(ConstructsBy.class).reflect(locator.type().rawType));
+			toConstructor(locator.type().rawType);
 		}
 
-		public void toConstructor(Class<? extends T> impl,
-				Hint<?>... hints) {
+		@SuppressWarnings("unchecked")
+		public void toConstructor(Class<? extends T> impl, Hint<?>... hints) {
 			if (!isClassInstantiable(impl))
 				throw InconsistentDeclaration.notConstructable(impl);
-			to(env(ConstructsBy.class).reflect(impl), hints);
+			to((Constructor<? extends T>) env(ConstructsBy.class).reflect(impl, hints), hints);
 		}
 
 		public void toConstructor(Hint<?>... hints) {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
@@ -703,6 +703,8 @@ public class Binder {
 		}
 
 		public <T> void asConstructor(Constructor<T> target, Hint<?>... hints) {
+			if (target == null)
+				throw InconsistentBinding.generic("Provided Constructor was null");
 			Name name = namesBy.reflect(target);
 			if (hints.length == 0)
 				hints = hintsBy.reflect(target);
@@ -895,6 +897,8 @@ public class Binder {
 		}
 
 		public void to(Constructor<? extends T> target, Hint<?>... hints) {
+			if (target == null)
+				throw InconsistentBinding.generic("Provided constructor was null");
 			if (hints.length == 0)
 				hints = env(HintsBy.class).reflect(target);
 			expand(New.newInstance(target, hints));
@@ -1019,8 +1023,13 @@ public class Binder {
 		public void toConstructor(Class<? extends T> impl, Hint<?>... hints) {
 			if (!isClassInstantiable(impl))
 				throw InconsistentDeclaration.notConstructable(impl);
-			to((Constructor<? extends T>) env(ConstructsBy.class)
-					.reflect(impl.getDeclaredConstructors(), hints), hints);
+			Constructor<? extends T> target = (Constructor<? extends T>)
+					env(ConstructsBy.class) //
+						.reflect(impl.getDeclaredConstructors(), hints);
+			if (target == null)
+				throw InconsistentBinding.generic(
+						"No usable Constructor for type: " + impl);
+			to(target, hints);
 		}
 
 		public void toConstructor(Hint<?>... hints) {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
@@ -652,7 +652,8 @@ public class Binder {
 			boolean needsInstance2 = bindSharesIn(service, instance);
 			if (!needsInstance1 && !needsInstance2)
 				return; // do not try to construct the class
-			Constructor<?> target = constructsBy.reflect(service);
+			Constructor<?> target = constructsBy
+					.reflect(service.getDeclaredConstructors(), hints);
 			if (target != null)
 				asConstructor(target, hints);
 		}
@@ -1018,7 +1019,8 @@ public class Binder {
 		public void toConstructor(Class<? extends T> impl, Hint<?>... hints) {
 			if (!isClassInstantiable(impl))
 				throw InconsistentDeclaration.notConstructable(impl);
-			to((Constructor<? extends T>) env(ConstructsBy.class).reflect(impl, hints), hints);
+			to((Constructor<? extends T>) env(ConstructsBy.class)
+					.reflect(impl.getDeclaredConstructors(), hints), hints);
 		}
 
 		public void toConstructor(Hint<?>... hints) {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
@@ -667,8 +667,11 @@ public class Binder {
 		}
 
 		private boolean bindSharesIn(Class<?> impl, Object instance) {
+			Field[] constants = sharesBy.reflect(impl);
+			if (constants == null || constants.length == 0)
+				return false;
 			boolean needsInstance = false;
-			for (Field constant : sharesBy.reflect(impl)) {
+			for (Field constant : constants) {
 				binder.per(Scope.container).bind(namesBy.reflect(constant),
 						fieldType(constant)).to(instance, constant);
 				needsInstance |= !isStatic(constant.getModifiers());

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModule.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModule.java
@@ -5,13 +5,16 @@
  */
 package se.jbee.inject.binder;
 
-import se.jbee.inject.*;
+import se.jbee.inject.Env;
+import se.jbee.inject.Name;
+import se.jbee.inject.Scope;
+import se.jbee.inject.ScopeLifeCycle;
+import se.jbee.inject.bind.Bindings;
+import se.jbee.inject.bind.Bootstrapper;
+import se.jbee.inject.bind.Bundle;
 import se.jbee.inject.bind.Module;
-import se.jbee.inject.bind.*;
-import se.jbee.inject.lang.Utils;
 
 import static se.jbee.inject.Scope.container;
-import static se.jbee.inject.lang.Type.raw;
 
 /**
  * The default utility {@link Module} almost always used.

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModule.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModule.java
@@ -53,7 +53,14 @@ public abstract class BinderModule extends InitializedBinder
 		declare();
 	}
 
-	protected Env configure(Env env) {
+	/**
+	 * Override this to customise the {@link Env} used within this {@link
+	 * BinderModule}.
+	 *
+	 * @param env The "global" {@link Env}
+	 * @return the adjusted {@link Env} for this {@link BinderModule}
+	 */
+	public Env configure(Env env) {
 		return env;
 	}
 

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModuleWith.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModuleWith.java
@@ -5,14 +5,14 @@
  */
 package se.jbee.inject.binder;
 
-import java.lang.annotation.Annotation;
-
 import se.jbee.inject.Env;
-import se.jbee.inject.lang.Type;
 import se.jbee.inject.bind.Bindings;
 import se.jbee.inject.bind.Bootstrapper;
 import se.jbee.inject.bind.Bundle;
 import se.jbee.inject.bind.ModuleWith;
+import se.jbee.inject.lang.Type;
+
+import java.lang.annotation.Annotation;
 
 /**
  * The default utility {@link ModuleWith}.

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BootstrapperBundle.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BootstrapperBundle.java
@@ -1,20 +1,17 @@
 /*
  *  Copyright (c) 2012-2019, Jan Bernitt
- *	
+ *
  *  Licensed under the Apache License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0
  */
 package se.jbee.inject.binder;
 
-import se.jbee.inject.bind.Bootstrapper;
-import se.jbee.inject.bind.Bundle;
-import se.jbee.inject.bind.InconsistentBinding;
 import se.jbee.inject.bind.Module;
-import se.jbee.inject.bind.Toggled;
+import se.jbee.inject.bind.*;
 
 /**
  * The default utility {@link Bundle} that is a {@link Bootstrapper} as well so
  * that bindings can be declared nicer.
- * 
+ *
  * @author Jan Bernitt (jan@jbee.se)
  */
 public abstract class BootstrapperBundle implements Bundle, Bootstrapper {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BundleFor.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BundleFor.java
@@ -6,11 +6,11 @@
 package se.jbee.inject.binder;
 
 import se.jbee.inject.bind.Bootstrapper;
-import se.jbee.inject.lang.Type;
+import se.jbee.inject.bind.Bootstrapper.ToggledBootstrapper;
 import se.jbee.inject.bind.Bundle;
 import se.jbee.inject.bind.InconsistentBinding;
 import se.jbee.inject.bind.Toggled;
-import se.jbee.inject.bind.Bootstrapper.ToggledBootstrapper;
+import se.jbee.inject.lang.Type;
 
 /**
  * The default utility base class for {@link Toggled}s.

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/New.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/New.java
@@ -5,12 +5,12 @@
  */
 package se.jbee.inject.binder;
 
-import java.lang.reflect.Constructor;
-
 import se.jbee.inject.Hint;
+import se.jbee.inject.bind.ValueBinder;
 import se.jbee.inject.lang.Type;
 import se.jbee.inject.lang.Typed;
-import se.jbee.inject.bind.ValueBinder;
+
+import java.lang.reflect.Constructor;
 
 /**
  * A {@link New} is the {@link ValueBinder} expansion wrapper for {@link Constructor}

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Produces.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Produces.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Method;
 
 import static java.lang.reflect.Modifier.isStatic;
 import static se.jbee.inject.lang.Type.parameterType;
+import static se.jbee.inject.lang.Type.raw;
 
 /**
  * A {@link Produces} is the {@link ValueBinder} expansion wrapper for a method
@@ -45,7 +46,7 @@ public final class Produces<T> implements Typed<T> {
 		this.isInstanceMethod = !isStatic(target.getModifiers());
 		Type.returnType(target).toSupertype(returns); // make sure types are compatible
 		if (owner != null
-			&& !owner.getClass().isAssignableFrom(target.getDeclaringClass())) {
+			&& !raw(owner.getClass()).isAssignableTo(raw(target.getDeclaringClass()))) {
 			throw new IllegalArgumentException(
 					"Owner of type " + owner.getClass()
 						+ " does not declare the target method: " + target);

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Produces.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Produces.java
@@ -5,15 +5,15 @@
  */
 package se.jbee.inject.binder;
 
-import static java.lang.reflect.Modifier.isStatic;
-import static se.jbee.inject.lang.Type.parameterType;
+import se.jbee.inject.Hint;
+import se.jbee.inject.bind.ValueBinder;
+import se.jbee.inject.lang.Type;
+import se.jbee.inject.lang.Typed;
 
 import java.lang.reflect.Method;
 
-import se.jbee.inject.Hint;
-import se.jbee.inject.lang.Type;
-import se.jbee.inject.lang.Typed;
-import se.jbee.inject.bind.ValueBinder;
+import static java.lang.reflect.Modifier.isStatic;
+import static se.jbee.inject.lang.Type.parameterType;
 
 /**
  * A {@link Produces} is the {@link ValueBinder} expansion wrapper for a method

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/ServiceLoaderAnnotations.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/ServiceLoaderAnnotations.java
@@ -1,14 +1,14 @@
 package se.jbee.inject.binder;
 
-import java.lang.annotation.Annotation;
-import java.util.ServiceLoader;
-
 import se.jbee.inject.Env;
 import se.jbee.inject.Extends;
 import se.jbee.inject.Name;
-import se.jbee.inject.lang.Type;
 import se.jbee.inject.bind.Module;
 import se.jbee.inject.bind.ModuleWith;
+import se.jbee.inject.lang.Type;
+
+import java.lang.annotation.Annotation;
+import java.util.ServiceLoader;
 
 /**
  * A {@link Module} that is meant to be installed during the bootstrapping of a

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Shares.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Shares.java
@@ -1,13 +1,13 @@
 package se.jbee.inject.binder;
 
-import static java.lang.reflect.Modifier.isStatic;
-import static se.jbee.inject.lang.Type.fieldType;
-
-import java.lang.reflect.Field;
-
 import se.jbee.inject.Supplier;
 import se.jbee.inject.lang.Type;
 import se.jbee.inject.lang.Typed;
+
+import java.lang.reflect.Field;
+
+import static java.lang.reflect.Modifier.isStatic;
+import static se.jbee.inject.lang.Type.fieldType;
 
 /**
  * Shares a value that is extracted from a field. The field is read each time

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Supply.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Supply.java
@@ -117,7 +117,7 @@ public final class Supply {
 	}
 
 	public static <T> Supplier<T> byNew(New<T> instantiation) {
-		return new Instantiation<>(instantiation.target, Hint.match(
+		return new Construct<>(instantiation.target, Hint.match(
 				parameterTypes(instantiation.target), instantiation.hints));
 	}
 
@@ -160,8 +160,6 @@ public final class Supply {
 	/**
 	 * A {@link Supplier} uses multiple different separate suppliers to provide
 	 * the elements of a array of the supplied type.
-	 *
-	 * @author Jan Bernitt (jan@jbee.se)
 	 */
 	private static final class PredefinedArraySupplier<E>
 			extends WithArgs<E[]> {
@@ -212,12 +210,12 @@ public final class Supply {
 
 	}
 
-	private static final class Instantiation<T> extends WithArgs<T>
+	private static final class Construct<T> extends WithArgs<T>
 			implements Annotated {
 
 		private final Constructor<T> target;
 
-		Instantiation(Constructor<T> target, Hint<?>[] args) {
+		Construct(Constructor<T> target, Hint<?>[] args) {
 			super(args);
 			this.target = target;
 		}

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/Config.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/Config.java
@@ -1,5 +1,9 @@
 package se.jbee.inject.config;
 
+import se.jbee.inject.*;
+
+import java.util.Optional;
+
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static se.jbee.inject.Dependency.dependency;
@@ -8,14 +12,6 @@ import static se.jbee.inject.Instance.instance;
 import static se.jbee.inject.Name.named;
 import static se.jbee.inject.lang.Type.raw;
 import static se.jbee.inject.lang.Utils.orElse;
-
-import java.util.Optional;
-
-import se.jbee.inject.ContextAware;
-import se.jbee.inject.Converter;
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Injector;
-import se.jbee.inject.Instance;
 
 /**
  * A {@link Config} is an {@link Extension} that uses the {@link Dependency}

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/ConstructsBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/ConstructsBy.java
@@ -54,7 +54,7 @@ public interface ConstructsBy {
 	 */
 	ConstructsBy OPTIMISTIC = FIRST
 			.ignore(Utils::isRecursiveTypeParameterPresent) // ignore looping ones
-			.select(Hint::matches) // ignore those that don't match provided Hints
+			.select(Hint::matchesInRandomOrder) // ignore those that don't match provided Hints
 			.sortedBy(Utils::mostVisibleMostParametersToLeastVisibleLeastParameters);
 
 	default ConstructsBy sortedBy(Comparator<Constructor<?>> cmp) {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/ConstructsBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/ConstructsBy.java
@@ -5,15 +5,16 @@
  */
 package se.jbee.inject.config;
 
-import static se.jbee.inject.lang.Utils.arrayFindFirst;
+import se.jbee.inject.Hint;
+import se.jbee.inject.lang.Utils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.function.Predicate;
 
-import se.jbee.inject.Hint;
-import se.jbee.inject.Packages;
-import se.jbee.inject.lang.Type;
-import se.jbee.inject.lang.Utils;
+import static se.jbee.inject.lang.Utils.arrayFilter;
 
 /**
  * Picks the {@link Constructor} to use to construct objects of a given
@@ -31,22 +32,39 @@ public interface ConstructsBy {
 	 *
 	 *         Returns {@code null} when no suitable constructor was found.
 	 */
-	Constructor<?> reflect(Class<?> type, Hint... hints);
+	Constructor<?> reflect(Constructor<?>[] candidates, Hint<?>... hints);
+
+	ConstructsBy FIRST = (candidates, hints) -> candidates.length == 0 ? null : candidates[0];
 
 	/**
-	 * Default value and starting point for custom {@link ConstructsBy}.
+	 * Is the {@link Constructor} that is most visible and out of those has the
+	 * most parameters but does not have a parameter that is the type itself (as
+	 * this would usually cause an endless loop when trying to inject it).
 	 */
-	ConstructsBy common = (type, hints) -> Utils.commonConstructorOrNull(type);
+	ConstructsBy OPTIMISTIC = FIRST
+			.ignore(Utils::isRecursiveTypeParameterPresent) //
+			.sortedBy(Utils::mostVisibleMostParametersToLeastVisibleLeastParameters);
 
-	default ConstructsBy in(Packages filter) {
-		return (type, hints) -> filter.contains(Type.raw(type)) ? reflect(type) : null;
+	default ConstructsBy sortedBy(Comparator<Constructor<?>> cmp) {
+		return (candidates, hints) -> {
+			if (candidates.length == 0) return null;
+			if (candidates.length == 1) return candidates[0];
+			Arrays.sort(candidates, cmp);
+			return reflect(candidates, hints);
+		};
+	}
+
+	default ConstructsBy ignore(Predicate<Constructor<?>> filter) {
+		return select(filter.negate());
+	}
+
+	default ConstructsBy select(Predicate<Constructor<?>> filter) {
+		return (candidates, hints) -> candidates.length == 0
+				? null
+				: reflect(arrayFilter(candidates, filter), hints);
 	}
 
 	default ConstructsBy annotatedWith(Class<? extends Annotation> marker) {
-		return (type, hints) -> {
-			Constructor<?> marked = arrayFindFirst(type.getDeclaredConstructors(),
-					c -> c.isAnnotationPresent(marker));
-			return marked != null ? marked : reflect(type);
-		};
+		return select(c -> c.isAnnotationPresent(marker));
 	}
 }

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/ConstructsBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/ConstructsBy.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import static se.jbee.inject.lang.Utils.arrayFilter;
@@ -34,15 +35,26 @@ public interface ConstructsBy {
 	 */
 	Constructor<?> reflect(Constructor<?>[] candidates, Hint<?>... hints);
 
-	ConstructsBy FIRST = (candidates, hints) -> candidates.length == 0 ? null : candidates[0];
+	/**
+	 * Simply returns the first candidate or null.
+	 * This is a good root when using {@link #sortedBy(Comparator)}.
+	 */
+	ConstructsBy FIRST = (candidates, hints) -> candidates.length == 0
+			? null
+			: candidates[0];
 
 	/**
 	 * Is the {@link Constructor} that is most visible and out of those has the
 	 * most parameters but does not have a parameter that is the type itself (as
 	 * this would usually cause an endless loop when trying to inject it).
+	 * <p>
+	 * The approach is to first sort the possible constructor accordingly,
+	 * remove problematic ones and go with the first of the resulting
+	 * candidates.
 	 */
 	ConstructsBy OPTIMISTIC = FIRST
-			.ignore(Utils::isRecursiveTypeParameterPresent) //
+			.ignore(Utils::isRecursiveTypeParameterPresent) // ignore looping ones
+			.select(Hint::matches) // ignore those that don't match provided Hints
 			.sortedBy(Utils::mostVisibleMostParametersToLeastVisibleLeastParameters);
 
 	default ConstructsBy sortedBy(Comparator<Constructor<?>> cmp) {
@@ -58,13 +70,24 @@ public interface ConstructsBy {
 		return select(filter.negate());
 	}
 
+	default ConstructsBy ignore(BiPredicate<Constructor<?>, Hint<?>[]> filter) {
+		return select(filter.negate());
+	}
+
 	default ConstructsBy select(Predicate<Constructor<?>> filter) {
 		return (candidates, hints) -> candidates.length == 0
 				? null
 				: reflect(arrayFilter(candidates, filter), hints);
 	}
 
+	default ConstructsBy select(BiPredicate<Constructor<?>, Hint<?>[]> filter) {
+		return (candidates, hints) -> candidates.length == 0
+				? null
+				: reflect(arrayFilter(candidates, c -> filter.test(c, hints)), hints);
+	}
+
 	default ConstructsBy annotatedWith(Class<? extends Annotation> marker) {
 		return select(c -> c.isAnnotationPresent(marker));
 	}
+
 }

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/Edition.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/Edition.java
@@ -5,11 +5,11 @@
  */
 package se.jbee.inject.config;
 
-import java.lang.annotation.Annotation;
-import java.util.EnumSet;
-
 import se.jbee.inject.Packages;
 import se.jbee.inject.lang.Type;
+
+import java.lang.annotation.Annotation;
+import java.util.EnumSet;
 
 /**
  * An {@link Edition} decides which features are contained in a specific setup.

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/Extension.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/Extension.java
@@ -9,7 +9,7 @@ import se.jbee.inject.lang.Utils;
  *
  * This means the marked type does not need to be bound explicitly. A singleton
  * instance per type is created using the type's
- * {@link Utils#commonConstructor(Class)}.
+ * {@link Utils#mostVisibleMostParametersConstructor(Class)}.
  *
  * @since 8.1
  */

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/HintsBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/HintsBy.java
@@ -5,22 +5,18 @@
  */
 package se.jbee.inject.config;
 
-import static se.jbee.inject.InconsistentDeclaration.annotationLacksProperty;
-import static se.jbee.inject.Instance.instance;
-import static se.jbee.inject.Name.named;
-import static se.jbee.inject.lang.Type.parameterTypes;
-import static se.jbee.inject.lang.Utils.annotationPropertyByType;
-import static se.jbee.inject.lang.Utils.arrayFindFirst;
+import se.jbee.inject.Dependency;
+import se.jbee.inject.Hint;
+import se.jbee.inject.Name;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Hint;
-import se.jbee.inject.Name;
-import se.jbee.inject.lang.Type;
+import static se.jbee.inject.Instance.instance;
+import static se.jbee.inject.lang.Type.parameterType;
 
 /**
  * Extracts the {@link Hint} hints used to resolve the {@link Dependency}s
@@ -32,53 +28,39 @@ import se.jbee.inject.lang.Type;
 public interface HintsBy {
 
 	/**
-	 * @return The {@link Hint} hints for the construction/invocation of
-	 *         the given object. This is either a
-	 *         {@link java.lang.reflect.Constructor} or a
-	 *         {@link java.lang.reflect.Method} Use a zero length array if there
-	 *         are no hits.
+	 * @return The {@link Hint} for the given {@link Parameter}.
 	 */
-	Hint<?>[] reflect(Executable obj);
+	Hint<?> reflect(Parameter param);
 
-	HintsBy noParameters = obj -> Hint.none();
+	default Hint<?>[] applyTo(Executable obj) {
+		if (obj.getParameterCount() == 0)
+			return Hint.none();
+		Hint<?>[] hints = new Hint[obj.getParameterCount()];
+		int hinted = 0;
+		int i = 0;
+		for (Parameter p : obj.getParameters()) {
+			Hint<?> hint = reflect(p);
+			if (hint == null) {
+				hint = Hint.relativeReferenceTo(parameterType(p));
+			} else {
+				hinted++;
+			}
+			hints[i++] = hint;
+		}
+		return hinted > 0 ? hints : Hint.none();
+	}
 
 	/**
 	 * A {@link HintsBy} that allows to specify the
 	 * {@link Annotation} which is used to indicate the instance {@link Name} of
 	 * a method parameter.
 	 */
-	default HintsBy unlessAnnotatedWith(
-			Class<? extends Annotation> naming) {
-		if (naming == null)
-			return this;
-		Method nameProperty = annotationPropertyByType(String.class, naming);
-		if (nameProperty == null)
-			throw annotationLacksProperty(String.class, naming);
-		return obj -> {
-			Annotation[][] ais = obj.getParameterAnnotations();
-			Type<?>[] tis = parameterTypes(obj);
-			Hint<?>[] res = new Hint[tis.length];
-			int named = 0;
-			for (int i = 0; i < res.length; i++) {
-				res[i] = Hint.relativeReferenceTo(tis[i]); // default
-				Annotation instance = arrayFindFirst(ais[i],
-						a -> naming == a.annotationType());
-				if (instance != null) {
-					//TODO nicer exception handling for invoke (same in other mirrors)
-					try {
-						String name = (String) nameProperty.invoke(instance);
-						if (!name.isEmpty()
-							&& !name.equals(nameProperty.getDefaultValue())) {
-							res[i] = instance(named(name), tis[i]).asHint();
-							named++;
-						}
-					} catch (Exception e) {
-						// gobble
-					}
-				}
-			}
-			return named == 0 ? this.reflect(obj) : res;
-
+	static HintsBy instanceReference(NamesBy namesBy) {
+		return param -> {
+			Name name = namesBy.reflect(param);
+			return name != null && !name.isDefault()
+					? Hint.relativeReferenceTo(instance(name, parameterType(param)))
+					: null;
 		};
 	}
 }

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/HintsBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/HintsBy.java
@@ -7,9 +7,10 @@ package se.jbee.inject.config;
 
 import se.jbee.inject.Dependency;
 import se.jbee.inject.Hint;
+import se.jbee.inject.Instance;
 import se.jbee.inject.Name;
+import se.jbee.inject.lang.Type;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -19,8 +20,16 @@ import static se.jbee.inject.Instance.instance;
 import static se.jbee.inject.lang.Type.parameterType;
 
 /**
- * Extracts the {@link Hint} hints used to resolve the {@link Dependency}s
- * of a {@link Method} or {@link Constructor} being injected.
+ * Extracts the {@link Hint} used to resolve the {@link Dependency}s for a
+ * {@link Method} or {@link Constructor} {@link Parameter}.
+ * <p>
+ * The binder API uses {@link #applyTo(Executable)} to resolve the {@link Hint}s
+ * for all {@link Parameter}s. By convention this uses a {@link
+ * Hint#relativeReferenceTo(Type)} for those {@link Parameter}s where the {@link
+ * HintsBy} strategy did return {@code null}. If {@code null} was returned for
+ * all {@link Parameter}s no {@link Hint}s will be used.
+ *
+ * @see NamesBy
  *
  * @since 8.1
  */
@@ -32,6 +41,13 @@ public interface HintsBy {
 	 */
 	Hint<?> reflect(Parameter param);
 
+	/**
+	 * Used by the binder API to resolve {@link Hint}s for an {@link
+	 * Executable}.
+	 *
+	 * @param obj the {@link Method} or {@link Constructor} to hint for
+	 * @return the {@link Hint}s to use, zero length array for no hints
+	 */
 	default Hint<?>[] applyTo(Executable obj) {
 		if (obj.getParameterCount() == 0)
 			return Hint.none();
@@ -41,6 +57,7 @@ public interface HintsBy {
 		for (Parameter p : obj.getParameters()) {
 			Hint<?> hint = reflect(p);
 			if (hint == null) {
+				// prevent misunderstanding a later given hint for another parameter
 				hint = Hint.relativeReferenceTo(parameterType(p));
 			} else {
 				hinted++;
@@ -50,15 +67,22 @@ public interface HintsBy {
 		return hinted > 0 ? hints : Hint.none();
 	}
 
+	default HintsBy orElse(HintsBy whenNull) {
+		return param -> {
+			Hint<?> hint = reflect(param);
+			return hint != null ? hint : whenNull.reflect(param);
+		};
+	}
+
 	/**
-	 * A {@link HintsBy} that allows to specify the
-	 * {@link Annotation} which is used to indicate the instance {@link Name} of
-	 * a method parameter.
+	 * Returns a strategy that return {@link Hint#relativeReferenceTo(Instance)}
+	 * in case the provided {@link NamesBy} strategy does return a {@link
+	 * Name}.
 	 */
 	static HintsBy instanceReference(NamesBy namesBy) {
 		return param -> {
 			Name name = namesBy.reflect(param);
-			return name != null && !name.isDefault()
+			return name != null
 					? Hint.relativeReferenceTo(instance(name, parameterType(param)))
 					: null;
 		};

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/NamesBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/NamesBy.java
@@ -42,6 +42,7 @@ public interface NamesBy {
 		};
 	}
 
+	@Deprecated // ask for mapper: annotation => name
 	default NamesBy unlessAnnotatedWith(Class<? extends Annotation> naming) {
 		if (naming == null)
 			return this;

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/NamesBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/NamesBy.java
@@ -25,6 +25,12 @@ import static se.jbee.inject.Name.named;
 @FunctionalInterface
 public interface NamesBy {
 
+	/**
+	 * Uses the name as declared in the Java source code. This is the {@link
+	 * Member#getName()}, the {@link Class#getSimpleName()} or the {@link
+	 * Parameter#getName()}. {@link Parameter} only use the name if {@link
+	 * Parameter#isNamePresent()}.
+	 */
 	NamesBy DECLARED_NAME = obj ->  {
 		if (obj instanceof Member) return named(((Member) obj).getName());
 		if (obj instanceof Class) return named(((Class<?>) obj).getSimpleName());

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/Plugins.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/Plugins.java
@@ -1,11 +1,11 @@
 package se.jbee.inject.config;
 
-import static se.jbee.inject.Dependency.dependency;
-import static se.jbee.inject.lang.Type.raw;
-
 import se.jbee.inject.Dependency;
 import se.jbee.inject.Injector;
 import se.jbee.inject.Name;
+
+import static se.jbee.inject.Dependency.dependency;
+import static se.jbee.inject.lang.Type.raw;
 
 /**
  * {@link Plugins} are an {@link Extension} that makes resolving plugged

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/ProducesBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/ProducesBy.java
@@ -5,10 +5,8 @@
  */
 package se.jbee.inject.config;
 
-import static java.util.Arrays.asList;
-import static se.jbee.inject.lang.Type.raw;
-import static se.jbee.inject.lang.Type.returnType;
-import static se.jbee.inject.lang.Utils.arrayFilter;
+import se.jbee.inject.Packages;
+import se.jbee.inject.lang.Type;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -19,8 +17,10 @@ import java.util.List;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
-import se.jbee.inject.Packages;
-import se.jbee.inject.lang.Type;
+import static java.util.Arrays.asList;
+import static se.jbee.inject.lang.Type.raw;
+import static se.jbee.inject.lang.Type.returnType;
+import static se.jbee.inject.lang.Utils.arrayFilter;
 
 /**
  * Extracts the relevant {@link Method}s for a given target {@link Class}. These

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/SharesBy.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/SharesBy.java
@@ -1,9 +1,7 @@
 package se.jbee.inject.config;
 
-import static java.util.Arrays.asList;
-import static se.jbee.inject.lang.Type.fieldType;
-import static se.jbee.inject.lang.Type.raw;
-import static se.jbee.inject.lang.Utils.arrayFilter;
+import se.jbee.inject.Packages;
+import se.jbee.inject.lang.Type;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -14,8 +12,10 @@ import java.util.List;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
-import se.jbee.inject.Packages;
-import se.jbee.inject.lang.Type;
+import static java.util.Arrays.asList;
+import static se.jbee.inject.lang.Type.fieldType;
+import static se.jbee.inject.lang.Type.raw;
+import static se.jbee.inject.lang.Utils.arrayFilter;
 
 /**
  * Picks the {@link Field}s that are bound as constants for the {@link Field}'s

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Bootstrap.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Bootstrap.java
@@ -149,7 +149,7 @@ public final class Bootstrap {
 		private <T> T createBundle(Class<T> bundle) {
 			// OBS: Here we do not use the env but always make the bundles accessible
 			// as this is kind of designed into the concept
-			return Utils.instantiate(bundle, Utils::accessible,
+			return Utils.construct(bundle, Utils::accessible,
 					e -> new InconsistentDeclaration("Failed to create bundle: " + bundle, e));
 		}
 

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Bootstrap.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Bootstrap.java
@@ -260,6 +260,5 @@ public final class Bootstrap {
 				if (!accu.contains(c))
 					addAllInstalledIn(c, accu);
 		}
-
 	}
 }

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Bootstrap.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Bootstrap.java
@@ -85,7 +85,9 @@ public final class Bootstrap {
 	public static Injector injector(Env env, Bindings bindings,
 			Module[] modules) {
 		return Container.injector(
-				Binding.disambiguate(bindings.declaredFrom(env, modules)));
+				env.globalProperty(BindingConsolidation.class) //
+						.consolidate(env,
+								(bindings.declaredFrom(env, modules))));
 	}
 
 	public static Modulariser modulariser(Env env) {
@@ -94,12 +96,6 @@ public final class Bootstrap {
 
 	public static Bundler bundler(Env env) {
 		return new BuiltinBootstrapper(env);
-	}
-
-	public static Binding<?>[] bindings(Env env, Class<? extends Bundle> root,
-			Bindings bindings) {
-		return Binding.disambiguate(bindings//
-				.declaredFrom(env, modulariser(env).modularise(root)));
 	}
 
 	private Bootstrap() {

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
@@ -1,10 +1,9 @@
 package se.jbee.inject.bootstrap;
 
 import se.jbee.inject.*;
-import se.jbee.inject.bind.InconsistentBinding;
-import se.jbee.inject.bind.ModuleWith;
-import se.jbee.inject.bind.ValueBinder;
+import se.jbee.inject.bind.*;
 import se.jbee.inject.config.*;
+import se.jbee.inject.defaults.DefaultBindingConsolidation;
 import se.jbee.inject.defaults.DefaultValueBinders;
 import se.jbee.inject.lang.Type;
 import se.jbee.inject.lang.Utils;
@@ -50,9 +49,10 @@ public final class Environment implements Env {
 			.with(ScopesBy.class, ScopesBy.alwaysDefault) //
 			.with(HintsBy.class, HintsBy.noParameters) //
 			.with(Annotated.Enhancer.class, Annotated.SOURCE) //
-			.with(Env.GP_USE_DEEP_REFLECTION, boolean.class, false) //
+			.with(BindingConsolidation.class, DefaultBindingConsolidation::consolidate) //
+			.with(Env.GP_USE_DEEP_REFLECTION, false) //
 			.with(Env.GP_DEEP_REFLECTION_PACKAGES, Packages.class, Packages.ALL) //
-			.with(Env.GP_USE_VERIFICATION, boolean.class, false) //
+			.with(Env.GP_USE_VERIFICATION,false) //
 			.readonly();
 
 	public static Environment override(Env overridden) {
@@ -110,6 +110,10 @@ public final class Environment implements Env {
 		if (decorated != null && override)
 			return decorated.property(qualifier, property, ns);
 		throw InconsistentBinding.undefinedEnvProperty(qualifier, property, ns);
+	}
+
+	public Environment with(String qualifier, boolean value) {
+		return with(qualifier, boolean.class, value);
 	}
 
 	public <T> Environment with(Class<T> globalProperty, T value) {

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
@@ -42,7 +42,7 @@ public final class Environment implements Env {
 			.withBinder(DefaultValueBinders.INSTANCE_REF) //
 			.withBinder(DefaultValueBinders.PARAMETRIZED_REF) //
 			.withBinder(DefaultValueBinders.ARRAY) //
-			.with(ConstructsBy.class, ConstructsBy.common) //
+			.with(ConstructsBy.class, ConstructsBy.OPTIMISTIC) //
 			.with(SharesBy.class, SharesBy.noFields) //
 			.with(ProducesBy.class, ProducesBy.noMethods) //
 			.with(NamesBy.class, NamesBy.defaultName) //

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
@@ -47,7 +47,7 @@ public final class Environment implements Env {
 			.withBinder(DefaultValueBinders.ARRAY) //
 			.with(ConstructsBy.class, ConstructsBy.OPTIMISTIC) //
 			.with(SharesBy.class, SharesBy.noFields) //
-			.with(ProducesBy.class, ProducesBy.noMethods) //
+			.with(ProducesBy.class, impl -> null) //
 			.with(NamesBy.class, obj -> Name.DEFAULT) //
 			.with(ScopesBy.class, ScopesBy.AUTO) //
 			.with(HintsBy.class, param -> null) //

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
@@ -1,7 +1,10 @@
 package se.jbee.inject.bootstrap;
 
 import se.jbee.inject.*;
-import se.jbee.inject.bind.*;
+import se.jbee.inject.bind.BindingConsolidation;
+import se.jbee.inject.bind.InconsistentBinding;
+import se.jbee.inject.bind.ModuleWith;
+import se.jbee.inject.bind.ValueBinder;
 import se.jbee.inject.config.*;
 import se.jbee.inject.defaults.DefaultBindingConsolidation;
 import se.jbee.inject.defaults.DefaultValueBinders;
@@ -45,9 +48,9 @@ public final class Environment implements Env {
 			.with(ConstructsBy.class, ConstructsBy.OPTIMISTIC) //
 			.with(SharesBy.class, SharesBy.noFields) //
 			.with(ProducesBy.class, ProducesBy.noMethods) //
-			.with(NamesBy.class, NamesBy.defaultName) //
-			.with(ScopesBy.class, ScopesBy.alwaysDefault) //
-			.with(HintsBy.class, HintsBy.noParameters) //
+			.with(NamesBy.class, obj -> Name.DEFAULT) //
+			.with(ScopesBy.class, ScopesBy.AUTO) //
+			.with(HintsBy.class, param -> null) //
 			.with(Annotated.Enhancer.class, Annotated.SOURCE) //
 			.with(BindingConsolidation.class, DefaultBindingConsolidation::consolidate) //
 			.with(Env.GP_USE_DEEP_REFLECTION, false) //
@@ -138,7 +141,7 @@ public final class Environment implements Env {
 	}
 
 	public <T> Environment withBinder(Class<? extends ValueBinder<T>> value) {
-		return withBinder(Utils.instantiate(value, this::accessible,
+		return withBinder(Utils.construct(value, this::accessible,
 				e -> new InconsistentDeclaration("Failed to create ValueBinder of type: " + value, e)));
 	}
 

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/Environment.java
@@ -46,7 +46,7 @@ public final class Environment implements Env {
 			.withBinder(DefaultValueBinders.PARAMETRIZED_REF) //
 			.withBinder(DefaultValueBinders.ARRAY) //
 			.with(ConstructsBy.class, ConstructsBy.OPTIMISTIC) //
-			.with(SharesBy.class, SharesBy.noFields) //
+			.with(SharesBy.class, impl -> null) //
 			.with(ProducesBy.class, impl -> null) //
 			.with(NamesBy.class, obj -> Name.DEFAULT) //
 			.with(ScopesBy.class, ScopesBy.AUTO) //

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/InjectorFeature.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/InjectorFeature.java
@@ -1,6 +1,7 @@
 package se.jbee.inject.bootstrap;
 
-import se.jbee.inject.*;
+import se.jbee.inject.Env;
+import se.jbee.inject.Injector;
 import se.jbee.inject.bind.Bindings;
 import se.jbee.inject.bind.Bootstrapper;
 import se.jbee.inject.bind.Bundle;

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultBindingConsolidation.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultBindingConsolidation.java
@@ -1,0 +1,117 @@
+package se.jbee.inject.defaults;
+
+import se.jbee.inject.*;
+import se.jbee.inject.UnresolvableDependency.NoResourceForDependency;
+import se.jbee.inject.bind.Binding;
+import se.jbee.inject.bind.BindingType;
+import se.jbee.inject.bind.InconsistentBinding;
+import se.jbee.inject.lang.Type;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.binarySearch;
+import static se.jbee.inject.lang.Utils.arrayOf;
+
+/**
+ * Is the default implementation for {@link se.jbee.inject.bind.BindingConsolidation}.
+ * <p>
+ * It does not implement the interface since it has no state. Use a method
+ * reference lambda on {@link #consolidate(Env, Binding[])} instead.
+ *
+ * @since 8.1
+ */
+public final class DefaultBindingConsolidation {
+
+	private DefaultBindingConsolidation() {
+		throw new UnsupportedOperationException("use lambda on consolidate");
+	}
+
+	/**
+	 * Removes those bindings that are ambiguous but also do not clash because
+	 * of different {@link DeclarationType}s that replace each other.
+	 */
+	public static Binding<?>[] consolidate(Env env, Binding<?>[] bindings) {
+		if (bindings.length <= 1)
+			return bindings;
+		List<Binding<?>> uniques = new ArrayList<>(bindings.length);
+		Arrays.sort(bindings);
+		uniques.add(bindings[0]);
+		int lastUniqueIndex = 0;
+		Set<Type<?>> required = new HashSet<>();
+		List<Binding<?>> dropped = new ArrayList<>();
+		for (int i = 1; i < bindings.length; i++) {
+			Binding<?> lastUnique = bindings[lastUniqueIndex];
+			Binding<?> current = bindings[i];
+			final boolean equalResource = lastUnique.signature.equalTo(
+					current.signature);
+			DeclarationType lastType = lastUnique.source.declarationType;
+			DeclarationType curType = current.source.declarationType;
+			if (equalResource && lastType.clashesWith(curType))
+				throw InconsistentBinding.clash(lastUnique, current);
+			if (curType == DeclarationType.REQUIRED) {
+				required.add(current.signature.type());
+			} else if (equalResource && (lastType.droppedWith(curType))) {
+				if (!isDuplicateIdenticalConstant(true, lastUnique,
+						current) && i - 1 == lastUniqueIndex) {
+					dropped.add(uniques.remove(uniques.size() - 1));
+				}
+				dropped.add(current);
+			} else if (!equalResource || !curType.replacedBy(lastType)) {
+				if (current.source.declarationType == DeclarationType.MULTI
+						&& isDuplicateIdenticalConstant(equalResource, lastUnique,
+						current)) {
+					dropped.add(current);
+				} else {
+					uniques.add(current);
+					lastUniqueIndex = i;
+				}
+			}
+		}
+		return withoutProvidedThatAreNotRequiredIn(env, uniques, required, dropped);
+	}
+
+	private static boolean isDuplicateIdenticalConstant(boolean equalResource,
+			Binding<?> lastUnique, Binding<?> current) {
+		return equalResource && current.type == BindingType.PREDEFINED
+				&& lastUnique.supplier.equals(current.supplier);
+	}
+
+	private static Binding<?>[] withoutProvidedThatAreNotRequiredIn(Env env,
+			List<Binding<?>> bindings, Set<Type<?>> required,
+			List<Binding<?>> dropped) {
+		List<Binding<?>> res = new ArrayList<>(bindings.size());
+		for (Binding<?> b : bindings) {
+			Type<?> type = b.signature.type();
+			if (b.source.declarationType != DeclarationType.PROVIDED
+					|| required.contains(type)) {
+				res.add(b);
+				required.remove(type);
+			}
+		}
+		if (!required.isEmpty())
+			throw new NoResourceForDependency(required, dropped);
+		return env.globalProperty(Env.GP_BIND_BINDINGS, false)
+			   ? withListItselfInserted(res)
+			   : arrayOf(res, Binding.class);
+	}
+
+	/**
+	 * This must look very confusing at first. What we want to do here is add a
+	 * {@link Binding} that has all the bindings as array including itself. But
+	 * this must be inserted at the correct sorting position. Because of the
+	 * hen-egg situation with the array itself we use {@link AtomicReference} as
+	 * a box that we can fill later.
+	 */
+	private static Binding<?>[] withListItselfInserted(List<Binding<?>> res) {
+		AtomicReference<Binding<?>[]> box = new AtomicReference<>();
+		Binding<?> self = Binding.binding(Locator.locator(Binding[].class),
+				BindingType.PREDEFINED, (dep, context) -> box.get(),
+				Scope.container, Source.source(Binding.class));
+		int insertIndex = -binarySearch(res, self, Binding::compareTo) - 1;
+		res.add(insertIndex, self);
+		Binding<?>[] array = arrayOf(res, Binding.class);
+		box.set(array);
+		return array;
+	}
+}

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultFeature.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultFeature.java
@@ -93,8 +93,7 @@ public enum DefaultFeature implements Toggled<DefaultFeature> {
 	OBTAINABLE(true),
 
 	/**
-	 * Adds: injection {@link Type}, {@link Instance}, {@link
-	 * Name} and {@link Dependency}.
+	 * Adds: injection {@link Type}, {@link Name} and {@link Dependency}.
 	 */
 	SELF(true)
 	;
@@ -348,9 +347,6 @@ public enum DefaultFeature implements Toggled<DefaultFeature> {
 					.starbind(Name.class) //
 					.toSupplier(SelfModule::supplyName);
 			asDefault().per(Scope.dependency) //
-					.starbind(Instance.class) //
-					.toSupplier(SelfModule::supplyInstance);
-			asDefault().per(Scope.dependency) //
 					.starbind(Dependency.class) //
 					.toSupplier(SelfModule::supplyDependency);
 		}
@@ -366,11 +362,6 @@ public enum DefaultFeature implements Toggled<DefaultFeature> {
 			return injected.dependency.name.isAny()
 				   ? injected.target.instance.name
 				   : injected.dependency.name;
-		}
-
-		private static Instance<?> supplyInstance(
-				Dependency<? super Instance<?>> dep, Injector context) {
-			return dep.injection(findTypeInjectionFrame(dep)).dependency;
 		}
 
 		private static Dependency<?> supplyDependency(

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultFeature.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultFeature.java
@@ -30,7 +30,7 @@ import static se.jbee.inject.lang.Type.raw;
 /**
  * Installs all the build-in functionality by using the core API.
  */
-public enum CoreFeature implements Toggled<CoreFeature> {
+public enum DefaultFeature implements Toggled<DefaultFeature> {
 	/**
 	 * Adds: {@link Provider}s can be injected for all bound types.
 	 */
@@ -90,19 +90,24 @@ public enum CoreFeature implements Toggled<CoreFeature> {
 	/**
 	 * Adds: {@link Obtainable}s
 	 */
-	OBTAINABLE(true)
+	OBTAINABLE(true),
 
+	/**
+	 * Adds: injection {@link Type}, {@link Instance}, {@link
+	 * Name} and {@link Dependency}.
+	 */
+	SELF(true)
 	;
 
 	public final boolean installedByDefault;
 
-	CoreFeature(boolean installedByDefault) {
+	DefaultFeature(boolean installedByDefault) {
 		this.installedByDefault = installedByDefault;
 	}
 
 	@Override
 	public void bootstrap(
-			Bootstrapper.ToggledBootstrapper<CoreFeature> bootstrapper) {
+			Bootstrapper.ToggledBootstrapper<DefaultFeature> bootstrapper) {
 		bootstrapper.install(ListBridgeModule.class, LIST);
 		bootstrapper.install(SetBridgeModule.class, SET);
 		bootstrapper.install(CollectionBridgeModule.class, COLLECTION);
@@ -116,6 +121,7 @@ public enum CoreFeature implements Toggled<CoreFeature> {
 		bootstrapper.install(PrimitiveArraysModule.class, PRIMITIVE_ARRAYS);
 		bootstrapper.install(AnnotatedWithModule.class, ANNOTATED_WITH);
 		bootstrapper.install(ObtainableModule.class, OBTAINABLE);
+		bootstrapper.install(SelfModule.class, SELF);
 	}
 
 	private static class LoggerModule extends BinderModule {
@@ -329,7 +335,60 @@ public enum CoreFeature implements Toggled<CoreFeature> {
 		protected void declare() {
 			asDefault().bind(Env.class).to(env());
 		}
+	}
 
+	private static final class SelfModule extends BinderModule {
+
+		@Override
+		protected void declare() {
+			asDefault().per(Scope.dependency) //
+					.starbind(Type.class) //
+					.toSupplier(SelfModule::supplyType);
+			asDefault().per(Scope.dependency) //
+					.starbind(Name.class) //
+					.toSupplier(SelfModule::supplyName);
+			asDefault().per(Scope.dependency) //
+					.starbind(Instance.class) //
+					.toSupplier(SelfModule::supplyInstance);
+			asDefault().per(Scope.dependency) //
+					.starbind(Dependency.class) //
+					.toSupplier(SelfModule::supplyDependency);
+		}
+
+		private static Type<?> supplyType(Dependency<? super Type<?>> dep,
+				Injector context) {
+			return dep.injection(findTypeInjectionFrame(dep)).dependency.type;
+		}
+
+		private static Name supplyName(Dependency<? super Name> dep,
+				Injector context) {
+			Injection injected = dep.injection(1);
+			return injected.dependency.name.isAny()
+				   ? injected.target.instance.name
+				   : injected.dependency.name;
+		}
+
+		private static Instance<?> supplyInstance(
+				Dependency<? super Instance<?>> dep, Injector context) {
+			return dep.injection(findTypeInjectionFrame(dep)).dependency;
+		}
+
+		private static Dependency<?> supplyDependency(
+				Dependency<? super Dependency<?>> dep, Injector context) {
+			return dep.onTypeParameter().uninject();
+		}
+
+		private static int findTypeInjectionFrame(Dependency<?> dep) {
+			Type<?> target = dep.injection(1).dependency.type;
+			if (!target.isRawType())
+				return 1;
+			for (int frame = 2; frame < dep.injectionDepth(); frame++) {
+				Type<?> candidate = dep.injection(frame).dependency.type;
+				if (candidate.rawType == target.rawType && !candidate.isRawType())
+					return frame;
+			}
+			return 1;
+		}
 	}
 
 	private static final class PrimitiveArraysModule extends BinderModule {

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultScopes.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultScopes.java
@@ -1,31 +1,21 @@
 package se.jbee.inject.defaults;
 
+import se.jbee.inject.*;
+import se.jbee.inject.bind.Bind;
+import se.jbee.inject.binder.BinderModule;
+import se.jbee.inject.config.Config;
+import se.jbee.inject.scope.*;
+
+import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
 import static se.jbee.inject.Name.named;
 import static se.jbee.inject.Scope.container;
 import static se.jbee.inject.ScopeLifeCycle.singleton;
 import static se.jbee.inject.ScopeLifeCycle.unstable;
 import static se.jbee.inject.scope.DiskScope.SYNC_INTERVAL;
 import static se.jbee.inject.scope.DiskScope.SYNC_INTERVAL_DEFAULT_DURATION;
-
-import java.io.File;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Injector;
-import se.jbee.inject.Name;
-import se.jbee.inject.Scope;
-import se.jbee.inject.ScopeLifeCycle;
-import se.jbee.inject.Supplier;
-import se.jbee.inject.UnresolvableDependency;
-import se.jbee.inject.bind.Bind;
-import se.jbee.inject.binder.BinderModule;
-import se.jbee.inject.config.Config;
-import se.jbee.inject.scope.ApplicationScope;
-import se.jbee.inject.scope.DiskScope;
-import se.jbee.inject.scope.ThreadScope;
-import se.jbee.inject.scope.TypeDependentScope;
-import se.jbee.inject.scope.WorkerScope;
 
 /**
  * Binds implementations for the standard {@link Scope}s declared as

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
@@ -194,10 +194,11 @@ public final class DefaultValueBinders {
 				return;
 			}
 			if (type.isInterface())
-				throw InconsistentBinding.loop(item, src, bound);
-			bindToMirrorConstructor(env, type.rawType, item, target);
+				throw InconsistentBinding.referenceLoop(item, src, bound);
+			bindToConstructsBy(env, type.rawType, item, target);
 		}
 
+		@SuppressWarnings({"unchecked", "rawtypes"})
 		private <T> boolean isCompatibleSupplier(Type<T> requiredType,
 				Type<?> providedType) {
 			if (!providedType.isAssignableTo(raw(Supplier.class)))
@@ -218,13 +219,13 @@ public final class DefaultValueBinders {
 					new Locator<>(src).indirect(item.signature.target.indirect),
 					BindingType.CONSTRUCTOR, null, item.scope,
 					item.source.typed(DeclarationType.IMPLICIT));
-			bindToMirrorConstructor(env, impl, binding, target);
+			bindToConstructsBy(env, impl, binding, target);
 		}
 	}
 
-	static <T> void bindToMirrorConstructor(Env env, Class<? extends T> src,
+	static <T> void bindToConstructsBy(Env env, Class<? extends T> src,
 			Binding<T> item, Bindings target) {
-		Constructor<? extends T> c = env.property(ConstructsBy.class,
+		Constructor<?> c = env.property(ConstructsBy.class,
 				item.source.pkg()).reflect(src);
 		if (c != null)
 			target.addExpanded(env, item, New.newInstance(c));

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
@@ -226,7 +226,7 @@ public final class DefaultValueBinders {
 	static <T> void bindToConstructsBy(Env env, Class<? extends T> src,
 			Binding<T> item, Bindings target) {
 		Constructor<?> c = env.property(ConstructsBy.class,
-				item.source.pkg()).reflect(src);
+				item.source.pkg()).reflect(src.getDeclaredConstructors());
 		if (c != null)
 			target.addExpanded(env, item, New.newInstance(c));
 	}

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
@@ -10,6 +10,7 @@ import se.jbee.inject.bind.*;
 import se.jbee.inject.binder.*;
 import se.jbee.inject.config.ConstructsBy;
 import se.jbee.inject.lang.Type;
+import se.jbee.inject.lang.Utils;
 
 import java.lang.reflect.Constructor;
 
@@ -171,7 +172,7 @@ public final class DefaultValueBinders {
 			Type<?> srcType = src.type();
 			if (avoidReferences && isClassBanal(srcType.rawType)) {
 				target.addExpanded(env, item,
-						new Constant<>(instantiate(srcType.rawType, env::accessible,
+						new Constant<>(Utils.construct(srcType.rawType, env::accessible,
 								RuntimeException::new)).manual());
 						//TODO shouldn't this use New instead?
 				return;
@@ -214,7 +215,7 @@ public final class DefaultValueBinders {
 	static <T> void implicitlyBindToConstructor(Env env, Instance<T> src,
 			Binding<?> item, Bindings target) {
 		Class<T> impl = src.type().rawType;
-		if (isClassInstantiable(impl)) {
+		if (isClassConstructable(impl)) {
 			Binding<T> binding = Binding.binding(
 					new Locator<>(src).indirect(item.signature.target.indirect),
 					BindingType.CONSTRUCTOR, null, item.scope,

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultValueBinders.java
@@ -47,7 +47,7 @@ public final class DefaultValueBinders {
 
 	/**
 	 * This {@link ValueBinder} adds bindings to super-types for
-	 * {@link Binding}s declared with {@link DeclarationType#AUTO} or
+	 * {@link Binding}s declared with {@link DeclarationType#SUPER} or
 	 * {@link DeclarationType#PROVIDED}.
 	 */
 	static final class SuperTypesBinder implements ValueBinder<Binding<?>> {
@@ -57,7 +57,7 @@ public final class DefaultValueBinders {
 				Bindings target) {
 			target.add(env, item);
 			DeclarationType declarationType = item.source.declarationType;
-			if (declarationType != DeclarationType.AUTO
+			if (declarationType != DeclarationType.SUPER
 				&& declarationType != DeclarationType.PROVIDED)
 				return;
 			for (Type<? super T> supertype : item.type().supertypes())

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultsBundle.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultsBundle.java
@@ -7,7 +7,7 @@ import se.jbee.inject.bind.Module;
 import se.jbee.inject.binder.BootstrapperBundle;
 
 /**
- * A {@link Bundle} that installs all {@link CoreFeature} features active by
+ * A {@link Bundle} that installs all {@link DefaultFeature} features active by
  * default. This means a {@link Injector} feature is implemented by providing a
  * {@link Resource} which is bound as a usual {@link Module}.
  *
@@ -17,7 +17,7 @@ public final class DefaultsBundle extends BootstrapperBundle {
 
 	@Override
 	protected void bootstrap() {
-		for (CoreFeature f : CoreFeature.values())
+		for (DefaultFeature f : DefaultFeature.values())
 			if (f.installedByDefault)
 				install(f);
 	}

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/ExtensionModule.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/ExtensionModule.java
@@ -40,7 +40,7 @@ class ExtensionModule extends BinderModule {
 	private static <T> T extension(ConstructsBy constructsBy, Dependency<?> dep,
 			Injector context) {
 		Constructor<T> ext = (Constructor<T>) constructsBy.reflect(
-				dep.type().rawType);
+				dep.type().rawType.getDeclaredConstructors());
 		context.resolve(Env.class).accessible(ext);
 		return Supply.byNew(newInstance(ext)) //
 				.supply((Dependency<? super T>) dep, context);

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/ExtensionModule.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/ExtensionModule.java
@@ -1,15 +1,15 @@
 package se.jbee.inject.defaults;
 
-import static se.jbee.inject.binder.New.newInstance;
-import static se.jbee.inject.lang.Type.raw;
-
-import java.lang.reflect.Constructor;
-
 import se.jbee.inject.*;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.Supply;
 import se.jbee.inject.config.ConstructsBy;
 import se.jbee.inject.config.Extension;
+
+import java.lang.reflect.Constructor;
+
+import static se.jbee.inject.binder.New.newInstance;
+import static se.jbee.inject.lang.Type.raw;
 
 /**
  * Provides a {@link Supplier} that can resolve all types extending an

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/package-info.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Contains {@link se.jbee.inject.bind.Bundle}s and {@link
  * se.jbee.inject.bind.Module}s that declare the {@link
- * se.jbee.inject.defaults.CoreFeature}s of the library that are build in top of
+ * se.jbee.inject.defaults.DefaultFeature}s of the library that are build in top of
  * the general container mechanism itself.
  *
  * <h2>Defaults</h2>
@@ -35,10 +35,10 @@
  * implementation for {@link se.jbee.inject.config.Extension} concept.
  * </p>
  * <p>
- * The {@link se.jbee.inject.defaults.CoreFeature} basic adapters that extend
+ * The {@link se.jbee.inject.defaults.DefaultFeature} basic adapters that extend
  * the range of types available based on other bound instances.
- * {@link se.jbee.inject.defaults.CoreFeature#ENV} and
- * {@link se.jbee.inject.defaults.CoreFeature#SUB_CONTEXT} are installed by
+ * {@link se.jbee.inject.defaults.DefaultFeature#ENV} and
+ * {@link se.jbee.inject.defaults.DefaultFeature#SUB_CONTEXT} are installed by
  * default.
  * </p>
  **/

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/ApplicationScope.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/ApplicationScope.java
@@ -1,20 +1,16 @@
 package se.jbee.inject.scope;
 
+import se.jbee.inject.*;
+
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
-
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Generator;
-import se.jbee.inject.Provider;
-import se.jbee.inject.Scope;
-import se.jbee.inject.UnresolvableDependency;
 
 /**
  * Asks the {@link Provider} once per binding. Thereby instances become
  * singletons local to the application.
- * 
+ *
  * Will lead to instances that can be seen as application-wide-singletons.
- * 
+ *
  * Contains an instance per {@link Generator}. Instances are never updated.
  */
 public final class ApplicationScope implements Scope {

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/DiskScope.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/DiskScope.java
@@ -1,8 +1,9 @@
 package se.jbee.inject.scope;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static se.jbee.inject.lang.Type.raw;
+import se.jbee.inject.Dependency;
+import se.jbee.inject.Provider;
+import se.jbee.inject.Scope;
+import se.jbee.inject.UnresolvableDependency;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -14,10 +15,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Provider;
-import se.jbee.inject.Scope;
-import se.jbee.inject.UnresolvableDependency;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static se.jbee.inject.lang.Type.raw;
 
 /**
  * The {@link DiskScope} is a {@link Scope} that persists objects on disk.

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/ThreadScope.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/ThreadScope.java
@@ -1,10 +1,6 @@
 package se.jbee.inject.scope;
 
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Provider;
-import se.jbee.inject.Resource;
-import se.jbee.inject.Scope;
-import se.jbee.inject.UnresolvableDependency;
+import se.jbee.inject.*;
 
 /**
  * Asks the {@link Provider} once per thread per {@link Resource} which is

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/TypeDependentScope.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/TypeDependentScope.java
@@ -1,15 +1,11 @@
 package se.jbee.inject.scope;
 
+import se.jbee.inject.*;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Function;
-
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Instance;
-import se.jbee.inject.Provider;
-import se.jbee.inject.Scope;
-import se.jbee.inject.UnresolvableDependency;
 
 /**
  * A {@link Scope} that maintains a map of instances where the key is derived

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/WorkerScope.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/scope/WorkerScope.java
@@ -1,13 +1,13 @@
 package se.jbee.inject.scope;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicReferenceArray;
-
 import se.jbee.inject.Dependency;
 import se.jbee.inject.Provider;
 import se.jbee.inject.Scope;
 import se.jbee.inject.UnresolvableDependency;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  * A {@link Scope} that is linked to the current {@link Thread} using the

--- a/se.jbee.inject.container/main/java/se/jbee/inject/container/Container.java
+++ b/se.jbee.inject.container/main/java/se/jbee/inject/container/Container.java
@@ -5,15 +5,9 @@
  */
 package se.jbee.inject.container;
 
-import static java.lang.System.identityHashCode;
-import static se.jbee.inject.Resource.resourcesTypeOf;
-import static se.jbee.inject.Dependency.dependency;
-import static se.jbee.inject.Instance.instance;
-import static se.jbee.inject.lang.Type.raw;
-import static se.jbee.inject.lang.Utils.arrayFilter;
-import static se.jbee.inject.lang.Utils.arrayFindFirst;
-import static se.jbee.inject.lang.Utils.arrayOf;
-import static se.jbee.inject.lang.Utils.orElse;
+import se.jbee.inject.*;
+import se.jbee.inject.UnresolvableDependency.NoResourceForDependency;
+import se.jbee.inject.lang.Type;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,9 +15,12 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import se.jbee.inject.*;
-import se.jbee.inject.lang.Type;
-import se.jbee.inject.UnresolvableDependency.NoResourceForDependency;
+import static java.lang.System.identityHashCode;
+import static se.jbee.inject.Dependency.dependency;
+import static se.jbee.inject.Instance.instance;
+import static se.jbee.inject.Resource.resourcesTypeOf;
+import static se.jbee.inject.lang.Type.raw;
+import static se.jbee.inject.lang.Utils.*;
 
 /**
  * The default {@link Injector} implementation that is based on

--- a/se.jbee.inject.container/main/java/se/jbee/inject/container/SupplyContext.java
+++ b/se.jbee.inject.container/main/java/se/jbee/inject/container/SupplyContext.java
@@ -1,10 +1,6 @@
 package se.jbee.inject.container;
 
-import se.jbee.inject.Dependency;
-import se.jbee.inject.Generator;
-import se.jbee.inject.Injector;
-import se.jbee.inject.Resource;
-import se.jbee.inject.Supplier;
+import se.jbee.inject.*;
 
 /**
  * The {@link SupplyContext} is an abstraction to the internals of a

--- a/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConverterModule.java
+++ b/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConverterModule.java
@@ -8,8 +8,6 @@ import se.jbee.inject.config.ScopesBy;
 import se.jbee.inject.config.SharesBy;
 import se.jbee.inject.lang.Type;
 
-import static se.jbee.inject.config.NamesBy.defaultName;
-import static se.jbee.inject.config.NamesBy.memberNameOr;
 import static se.jbee.inject.lang.Type.classType;
 
 /**
@@ -33,7 +31,6 @@ public abstract class ConverterModule extends BinderModule {
 	private static final Type<Converter> ANY_CONVERTER_TYPE = classType(
 			Converter.class);
 
-	private static final NamesBy NAME_BY = memberNameOr(defaultName);
 	private static final ProducesBy PRODUCES_BY = ProducesBy.declaredMethods //
 			.returnTypeAssignableTo(ANY_CONVERTER_TYPE);
 	private static final SharesBy SHARES_BY = SharesBy.declaredFields //
@@ -46,8 +43,8 @@ public abstract class ConverterModule extends BinderModule {
 
 	protected final AutoBinder autobindConverters() {
 		return autobind() //
-				.nameBy(NAME_BY) //
-				.scopeBy(ScopesBy.type) //
+				.nameBy(NamesBy.DECLARED_NAME) //
+				.scopeBy(ScopesBy.RETURN_TYPE) //
 				.shareBy(SHARES_BY) //
 				.produceBy(PRODUCES_BY);
 	}

--- a/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConverterModule.java
+++ b/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConverterModule.java
@@ -31,7 +31,7 @@ public abstract class ConverterModule extends BinderModule {
 	private static final Type<Converter> ANY_CONVERTER_TYPE = classType(
 			Converter.class);
 
-	private static final ProducesBy PRODUCES_BY = ProducesBy.declaredMethods //
+	private static final ProducesBy PRODUCES_BY = ProducesBy.OPTIMISTIC //
 			.returnTypeAssignableTo(ANY_CONVERTER_TYPE);
 	private static final SharesBy SHARES_BY = SharesBy.declaredFields //
 			.typeAssignableTo(ANY_CONVERTER_TYPE);

--- a/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConverterModule.java
+++ b/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConverterModule.java
@@ -33,7 +33,7 @@ public abstract class ConverterModule extends BinderModule {
 
 	private static final ProducesBy PRODUCES_BY = ProducesBy.OPTIMISTIC //
 			.returnTypeAssignableTo(ANY_CONVERTER_TYPE);
-	private static final SharesBy SHARES_BY = SharesBy.declaredFields //
+	private static final SharesBy SHARES_BY = SharesBy.declaredFields(false) //
 			.typeAssignableTo(ANY_CONVERTER_TYPE);
 
 	@Override

--- a/se.jbee.inject.convert/main/java/se/jbee/inject/convert/Converts.java
+++ b/se.jbee.inject.convert/main/java/se/jbee/inject/convert/Converts.java
@@ -1,14 +1,11 @@
 package se.jbee.inject.convert;
 
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Repeatable(ConvertsMultiple.class)
 @Retention(RUNTIME)

--- a/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConvertsMultiple.java
+++ b/se.jbee.inject.convert/main/java/se/jbee/inject/convert/ConvertsMultiple.java
@@ -1,10 +1,10 @@
 package se.jbee.inject.convert;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)

--- a/se.jbee.inject.convert/main/java/se/jbee/inject/convert/Imported.java
+++ b/se.jbee.inject.convert/main/java/se/jbee/inject/convert/Imported.java
@@ -1,43 +1,16 @@
 package se.jbee.inject.convert;
 
+import se.jbee.inject.lang.Type;
+
 import java.io.Closeable;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
-import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
-import java.util.function.DoubleConsumer;
-import java.util.function.DoubleFunction;
-import java.util.function.DoubleSupplier;
-import java.util.function.Function;
-import java.util.function.IntConsumer;
-import java.util.function.IntFunction;
-import java.util.function.IntSupplier;
-import java.util.function.LongConsumer;
-import java.util.function.LongFunction;
-import java.util.function.LongSupplier;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
+import java.util.function.*;
 import java.util.stream.Stream;
-
-import se.jbee.inject.lang.Type;
 
 /**
  * <p>

--- a/se.jbee.inject.convert/main/java/se/jbee/inject/convert/Imports.java
+++ b/se.jbee.inject.convert/main/java/se/jbee/inject/convert/Imports.java
@@ -1,15 +1,10 @@
 package se.jbee.inject.convert;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @Target({ TYPE, METHOD, FIELD, CONSTRUCTOR, ANNOTATION_TYPE, PARAMETER })

--- a/se.jbee.inject.event/main/java/se/jbee/inject/event/ConcurrentEventProcessor.java
+++ b/se.jbee.inject.event/main/java/se/jbee/inject/event/ConcurrentEventProcessor.java
@@ -5,9 +5,7 @@
  */
 package se.jbee.inject.event;
 
-import static java.lang.reflect.Proxy.newProxyInstance;
-import static se.jbee.inject.lang.Type.returnType;
-import static se.jbee.inject.event.EventException.unwrapGet;
+import se.jbee.inject.lang.Type;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -15,17 +13,13 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BinaryOperator;
 
-import se.jbee.inject.lang.Type;
+import static java.lang.reflect.Proxy.newProxyInstance;
+import static se.jbee.inject.event.EventException.unwrapGet;
+import static se.jbee.inject.lang.Type.returnType;
 
 /**
  * Default implementation of the {@link EventProcessor} supporting all

--- a/se.jbee.inject.event/main/java/se/jbee/inject/event/Event.java
+++ b/se.jbee.inject.event/main/java/se/jbee/inject/event/Event.java
@@ -5,12 +5,12 @@
  */
 package se.jbee.inject.event;
 
-import static java.lang.System.currentTimeMillis;
+import se.jbee.inject.lang.Type;
 
 import java.lang.reflect.Method;
 import java.util.function.BinaryOperator;
 
-import se.jbee.inject.lang.Type;
+import static java.lang.System.currentTimeMillis;
 
 /**
  * The message describing the handler interface method invocation as data.

--- a/se.jbee.inject.event/main/java/se/jbee/inject/event/EventException.java
+++ b/se.jbee.inject.event/main/java/se/jbee/inject/event/EventException.java
@@ -6,11 +6,7 @@
 package se.jbee.inject.event;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 /**
  * Is thrown by the event interface proxy for calls that should return a value

--- a/se.jbee.inject.event/main/java/se/jbee/inject/event/EventModule.java
+++ b/se.jbee.inject.event/main/java/se/jbee/inject/event/EventModule.java
@@ -5,11 +5,11 @@
  */
 package se.jbee.inject.event;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import se.jbee.inject.bind.Module;
 import se.jbee.inject.binder.BinderModule;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Base {@link Module} for modules that want to make known a handler to the

--- a/se.jbee.inject.event/main/java/se/jbee/inject/event/EventPolicy.java
+++ b/se.jbee.inject.event/main/java/se/jbee/inject/event/EventPolicy.java
@@ -5,13 +5,13 @@
  */
 package se.jbee.inject.event;
 
-import static java.lang.Math.max;
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BinaryOperator;
+
+import static java.lang.Math.max;
 
 /**
  * A {@link EventPolicy} controls how the {@link Event}s are processed by a

--- a/se.jbee.inject.event/main/java/se/jbee/inject/event/EventProcessor.java
+++ b/se.jbee.inject.event/main/java/se/jbee/inject/event/EventProcessor.java
@@ -5,12 +5,12 @@
  */
 package se.jbee.inject.event;
 
+import se.jbee.inject.BuildUp;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
-
-import se.jbee.inject.BuildUp;
 
 /**
  * The {@link EventProcessor} is the unit that functionally connects the

--- a/se.jbee.inject.event/main/java/se/jbee/inject/event/UnboxingFuture.java
+++ b/se.jbee.inject.event/main/java/se/jbee/inject/event/UnboxingFuture.java
@@ -5,13 +5,13 @@
  */
 package se.jbee.inject.event;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * When computing something asynchronously that itself returns a {@link Future}

--- a/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Cast.java
+++ b/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Cast.java
@@ -5,14 +5,12 @@
  */
 package se.jbee.inject.lang;
 
-import se.jbee.inject.lang.Type;
-
-import static se.jbee.inject.lang.Type.raw;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+
+import static se.jbee.inject.lang.Type.raw;
 
 /**
  * Utility to get rid of warnings for JRE generic {@link Type}s.

--- a/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Reflect.java
+++ b/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Reflect.java
@@ -1,0 +1,5 @@
+package se.jbee.inject.lang;
+
+public class Reflect {
+	//TODO move the reflection stuff here that can go wrong
+}

--- a/se.jbee.inject.lang/main/java/se/jbee/inject/lang/TypeVariable.java
+++ b/se.jbee.inject.lang/main/java/se/jbee/inject/lang/TypeVariable.java
@@ -1,14 +1,14 @@
 package se.jbee.inject.lang;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.WildcardType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 
 /**
  * A utility to help extract actual {@link Type} of

--- a/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Utils.java
+++ b/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Utils.java
@@ -6,7 +6,10 @@
 package se.jbee.inject.lang;
 
 import java.lang.reflect.*;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.*;
 
 import static java.lang.System.arraycopy;
@@ -37,6 +40,20 @@ public final class Utils {
 	}
 
 	/* Arrays */
+
+	public static <T> T[] arrayConcat(T[] a, T[] b) {
+		if (a == null)
+			return b;
+		if (b == null)
+			return a;
+		if (a.length == 0)
+			return b;
+		if (b.length == 0)
+			return a;
+		T[] both = Arrays.copyOf(a, a.length + b.length);
+		System.arraycopy(b, 0, both, a.length, b.length);
+		return both;
+	}
 
 	/**
 	 * This implementation assumes that the array passed is usually short (< 20)
@@ -201,6 +218,24 @@ public final class Utils {
 		return list.toArray(newArray(type, list.size()));
 	}
 
+	public static <A, B> List<B> arrayFilter(Class<A> root, Class<?> top,
+			Function<Class<?>, B[]> map2elems, Predicate<B> filter) {
+		List<B> res = new ArrayList<>();
+		arrayFilter(root, top, map2elems, filter, res);
+		return res;
+	}
+
+	public static <A, B> void arrayFilter(Class<A> root, Class<?> top,
+			Function<Class<?>, B[]> map2elems, Predicate<B> filter,
+			List<B> acc) {
+		if (root == null || root == top)
+			return;
+		for (B e : map2elems.apply(root))
+			if (filter == null || filter.test(e))
+				acc.add(e);
+		arrayFilter(root.getSuperclass(), top, map2elems, filter, acc);
+	}
+
 	/* Classes / Types */
 
 	/**
@@ -327,7 +362,7 @@ public final class Utils {
 		}
 	}
 
-	/* Sequences */
+	/* Char Sequences */
 
 	public static boolean seqRegionEquals(CharSequence s1, CharSequence s2,
 			int length) {

--- a/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Utils.java
+++ b/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Utils.java
@@ -225,15 +225,15 @@ public final class Utils {
 		return res;
 	}
 
-	public static <A, B> void arrayFilter(Class<A> root, Class<?> top,
+	public static <A, B> void arrayFilter(Class<A> root, Class<?> end,
 			Function<Class<?>, B[]> map2elems, Predicate<B> filter,
 			List<B> acc) {
-		if (root == null || root == top)
+		if (root == null || root == end)
 			return;
 		for (B e : map2elems.apply(root))
 			if (filter == null || filter.test(e))
 				acc.add(e);
-		arrayFilter(root.getSuperclass(), top, map2elems, filter, acc);
+		arrayFilter(root.getSuperclass(), end, map2elems, filter, acc);
 	}
 
 	/* Classes / Types */

--- a/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Utils.java
+++ b/se.jbee.inject.lang/main/java/se/jbee/inject/lang/Utils.java
@@ -277,7 +277,7 @@ public final class Utils {
 	}
 
 	public static boolean isClassInstantiable(Class<?> cls) {
-		return !isClassVirtual(cls) && cls.getTypeParameters().length == 0;
+		return !isClassVirtual(cls);
 	}
 
 	/**

--- a/test.example.app/test/java/test/example/app/Support.java
+++ b/test.example.app/test/java/test/example/app/Support.java
@@ -1,10 +1,10 @@
 package test.example.app;
 
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Target(TYPE)
 public @Retention(RUNTIME) @interface Support {

--- a/test.example.app/test/java/test/example/app/SupportAnnotationPattern.java
+++ b/test.example.app/test/java/test/example/app/SupportAnnotationPattern.java
@@ -1,11 +1,11 @@
 package test.example.app;
 
-import java.lang.annotation.Annotation;
-import java.util.ServiceLoader;
-
+import se.jbee.inject.Extends;
 import se.jbee.inject.Scope;
 import se.jbee.inject.binder.BinderModuleWith;
-import se.jbee.inject.Extends;
+
+import java.lang.annotation.Annotation;
+import java.util.ServiceLoader;
 
 /**
  * This is bound to the annotation

--- a/test.example.app/test/java/test/example/app/SupportAnnotationPattern.java
+++ b/test.example.app/test/java/test/example/app/SupportAnnotationPattern.java
@@ -27,6 +27,6 @@ public class SupportAnnotationPattern extends BinderModuleWith<Class<?>> {
 
 	@Override
 	protected void declare(Class<?> annotated) {
-		per(Scope.application).autobind(annotated).toConstructor();
+		per(Scope.application).superbind(annotated).toConstructor();
 	}
 }

--- a/test.integration/test/java/test/integration/action/TestExampleAnnotatedActionsBinds.java
+++ b/test.integration/test/java/test/integration/action/TestExampleAnnotatedActionsBinds.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.*;
 import static se.jbee.inject.action.Action.actionTypeOf;
-import static se.jbee.inject.config.ProducesBy.declaredMethods;
+import static se.jbee.inject.config.ProducesBy.OPTIMISTIC;
 
 /**
  * The simple example that shows how {@link java.lang.reflect.Method}s used as
@@ -39,7 +39,7 @@ class TestExampleAnnotatedActionsBinds {
 		@Override
 		protected void declare() {
 			construct(Bean.class);
-			connect(declaredMethods.annotatedWith(Marker.class)) //
+			connect(OPTIMISTIC.annotatedWith(Marker.class)) //
 					.in(Bean.class).asAction();
 		}
 	}
@@ -91,7 +91,7 @@ class TestExampleAnnotatedActionsBinds {
 	@Test
 	void annotatedMethodIsBoundAsActionWithGlobalSelector() {
 		Env env = Environment.DEFAULT.with(Binder.CONNECT_QUALIFIER,
-				ProducesBy.class, declaredMethods.annotatedWith(Marker.class));
+				ProducesBy.class, OPTIMISTIC.annotatedWith(Marker.class));
 		annotatedMethodIsBoundAsAction(Bootstrap.injector(env,
 				TestExampleAnnotatedActionsBindsModule2.class));
 	}
@@ -99,7 +99,7 @@ class TestExampleAnnotatedActionsBinds {
 	@Test
 	void notAnnotatedMethodIsNotBoundAsActionWithGlobalSelector() {
 		Env env = Environment.DEFAULT.with(Binder.CONNECT_QUALIFIER,
-				ProducesBy.class, declaredMethods.annotatedWith(Marker.class));
+				ProducesBy.class, OPTIMISTIC.annotatedWith(Marker.class));
 		notAnnotatedMethodIsNotBoundAsAction(Bootstrap.injector(env,
 				TestExampleAnnotatedActionsBindsModule2.class));
 	}

--- a/test.integration/test/java/test/integration/action/TestExampleCommandFacadeBinds.java
+++ b/test.integration/test/java/test/integration/action/TestExampleCommandFacadeBinds.java
@@ -7,11 +7,11 @@ import se.jbee.inject.Scope;
 import se.jbee.inject.action.Action;
 import se.jbee.inject.action.ActionModule;
 import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.config.ProducesBy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static se.jbee.inject.action.Action.actionTypeOf;
-import static se.jbee.inject.config.ProducesBy.allMethods;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -30,6 +30,7 @@ import static se.jbee.inject.lang.Type.raw;
  */
 class TestExampleCommandFacadeBinds {
 
+	@FunctionalInterface
 	private interface Command<P> {
 
 		long calc(P param);
@@ -40,7 +41,7 @@ class TestExampleCommandFacadeBinds {
 		@Override
 		protected void declare() {
 			construct(MathService.class);
-			connect(allMethods).in(MathService.class).asAction();
+			connect(ProducesBy.OPTIMISTIC).in(MathService.class).asAction();
 			per(Scope.dependencyType) //
 					.starbind(Command.class) //
 					.toSupplier(CommandModule::supply);

--- a/test.integration/test/java/test/integration/action/TestExampleServiceFacadeBinds.java
+++ b/test.integration/test/java/test/integration/action/TestExampleServiceFacadeBinds.java
@@ -7,12 +7,12 @@ import se.jbee.inject.Scope;
 import se.jbee.inject.action.Action;
 import se.jbee.inject.action.ActionModule;
 import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.config.ProducesBy;
 import se.jbee.inject.lang.Type;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static se.jbee.inject.action.Action.actionTypeOf;
-import static se.jbee.inject.config.ProducesBy.allMethods;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -49,7 +49,7 @@ class TestExampleServiceFacadeBinds {
 		protected void declare() {
 			construct(MathService.class);
 			construct(MathDependentService.class);
-			connect(allMethods).in(MathService.class).asAction();
+			connect(ProducesBy.OPTIMISTIC).in(MathService.class).asAction();
 			per(Scope.dependencyType)
 					.starbind(Service.class) //
 					.toSupplier(ServiceModule::supply);

--- a/test.integration/test/java/test/integration/action/TestExampleServiceInterceptorBinds.java
+++ b/test.integration/test/java/test/integration/action/TestExampleServiceInterceptorBinds.java
@@ -4,12 +4,12 @@ import org.junit.jupiter.api.Test;
 import se.jbee.inject.Injector;
 import se.jbee.inject.action.*;
 import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.config.ProducesBy;
 import se.jbee.inject.lang.Type;
 
 import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static se.jbee.inject.config.ProducesBy.allMethods;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -60,7 +60,7 @@ class TestExampleServiceInterceptorBinds {
 		@Override
 		protected void declare() {
 			construct(TheService.class);
-			connect(allMethods).in(TheService.class).asAction();
+			connect(ProducesBy.OPTIMISTIC).in(TheService.class).asAction();
 			// register the interceptor
 			plug(AssertInvocationInterceptor.class) //
 					.into(ServiceInterceptor.class);

--- a/test.integration/test/java/test/integration/action/TestFeatureActionBinds.java
+++ b/test.integration/test/java/test/integration/action/TestFeatureActionBinds.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static se.jbee.inject.Scope.dependencyInstance;
 import static se.jbee.inject.Scope.dependencyType;
 import static se.jbee.inject.action.Action.actionTypeOf;
-import static se.jbee.inject.config.ProducesBy.allMethods;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -69,7 +68,7 @@ class TestFeatureActionBinds {
 			per(dependencyInstance).bind(Name.ANY, HandlerService.class).toConstructor();
 			per(dependencyType).bind(GenericService.class).toConstructor();
 
-			ConnectBinder connectAll = connect(allMethods);
+			ConnectBinder connectAll = connect(ProducesBy.OPTIMISTIC);
 			connectAll.in(MyService.class).asAction();
 			connectAll.in(MyOtherService.class).asAction();
 			connectAll.in(HandlerService.class).asAction();

--- a/test.integration/test/java/test/integration/api/TestDeclarationType.java
+++ b/test.integration/test/java/test/integration/api/TestDeclarationType.java
@@ -29,12 +29,12 @@ class TestDeclarationType {
 	void thatImplicitDefaultAutoReplacedByMulti() {
 		assertTrue(IMPLICIT.replacedBy(MULTI));
 		assertTrue(DEFAULT.replacedBy(MULTI));
-		assertTrue(AUTO.replacedBy(MULTI));
+		assertTrue(SUPER.replacedBy(MULTI));
 	}
 
 	@Test
 	void thatDefaultReplacedByAutoMultiOrExplicit() {
-		assertTrue(DEFAULT.replacedBy(AUTO));
+		assertTrue(DEFAULT.replacedBy(SUPER));
 		assertTrue(DEFAULT.replacedBy(MULTI));
 		assertTrue(DEFAULT.replacedBy(EXPLICIT));
 	}
@@ -60,7 +60,7 @@ class TestDeclarationType {
 
 	@Test
 	void thatAutoNotClashesWithAuto() {
-		assertFalse(AUTO.clashesWith(AUTO));
+		assertFalse(SUPER.clashesWith(SUPER));
 	}
 
 	@Test

--- a/test.integration/test/java/test/integration/api/TestMoreQualified.java
+++ b/test.integration/test/java/test/integration/api/TestMoreQualified.java
@@ -121,7 +121,7 @@ class TestMoreQualified {
 	void thatExplicitSourceIsMoreApplicableThanAutoSource() {
 		Source source = Source.source(TestMoreQualified.class);
 		assertMoreApplicable(source.typed(DeclarationType.EXPLICIT),
-				source.typed(DeclarationType.AUTO));
+				source.typed(DeclarationType.SUPER));
 	}
 
 	private static <T extends Qualifying<? super T>> void assertMoreApplicable(

--- a/test.integration/test/java/test/integration/bind/TestBasicAutoBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicAutoBinds.java
@@ -1,0 +1,6 @@
+package test.integration.bind;
+
+public class TestBasicAutoBinds {
+
+	// TODO use Hint.signature and ProducesBy.selectBy Hint[] to see if we get the method bound we expect
+}

--- a/test.integration/test/java/test/integration/bind/TestBasicAutoBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicAutoBinds.java
@@ -1,6 +1,155 @@
 package test.integration.bind;
 
-public class TestBasicAutoBinds {
+import org.junit.jupiter.api.Test;
+import se.jbee.inject.*;
+import se.jbee.inject.binder.Binder;
+import se.jbee.inject.binder.BinderModule;
+import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.config.NamesBy;
+import se.jbee.inject.config.ProducesBy;
+import se.jbee.inject.config.SharesBy;
 
-	// TODO use Hint.signature and ProducesBy.selectBy Hint[] to see if we get the method bound we expect
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+import static se.jbee.inject.lang.Type.raw;
+
+/**
+ * A test that shows usage of {@link Binder.ScopedBinder#autobind()}.
+ * <p>
+ * As the name 'auto' suggest this is a way of binding {@link
+ * java.lang.reflect.Constructor}s, {@link java.lang.reflect.Method}s and {@link
+ * java.lang.reflect.Field} in a (semi-) automatic way.
+ * <p>
+ * The user configures the selection process using strategy interfaces {@link
+ * se.jbee.inject.config.ConstructsBy}, {@link ProducesBy}, {@link SharesBy} to
+ * programmatically describe how to find and select the members to use and bind.
+ * The created bindings can be further customised using the {@link
+ * se.jbee.inject.config.ScopesBy} strategy to decide the {@link
+ * se.jbee.inject.Scope} used, and {@link se.jbee.inject.config.HintsBy} to
+ * decides what arguments to use for {@link java.lang.reflect.Parameter}s of
+ * bound {@link java.lang.reflect.Executable}s.
+ * <p>
+ * All this strategies are "globally" bound in the {@link se.jbee.inject.Env}
+ * simply using {@link se.jbee.inject.bootstrap.Environment#with(Class,
+ * Object)}. These settings can be adjusted, overridden or replaced per {@link
+ * BinderModule} by overriding it {@link BinderModule#configure(Env)} method.
+ * Last but not least the strategies can be set individually just for the {@link
+ * Binder.ScopedBinder#autobind()} call using its {@link
+ * se.jbee.inject.binder.Binder.AutoBinder#produceBy(ProducesBy)} (and similar)
+ * methods.
+ */
+class TestBasicAutoBinds {
+
+	public static class TestBasicAutoBindsModule extends BinderModule {
+
+		public int i = 12;
+		public String s = "prefix";
+		public long l = 42L;
+
+		@Override
+		protected void declare() {
+			// share field values for the primitives in this test
+			autobind().shareBy(SharesBy.declaredFields(false)).in(this);
+
+			// bind methods as factories using Hint to find the one we want
+			autobind().produceBy(ProducesBy.OPTIMISTIC //
+					.selectStrictBy(Hint.signature(String.class, Integer.class))) //
+					.in(SelectMethodFromHints.class);
+
+			// bind methods as factories testing OR and OR-ELSE
+			ProducesBy flat = ProducesBy.declaredMethods(false);
+			autobind().nameBy(NamesBy.DECLARED_NAME) // use method names to avoid clashing binds
+					.produceBy(
+						flat.returnTypeAssignableTo(raw(boolean.class)) // returning booleans
+							.orElse(flat.withModifier(Modifier::isFinal)) // or if they are final
+							.or(flat.returnTypeAssignableTo(raw(int.class)))) // as well as any method returning an int
+					.in(SelectMethodOrAndOrElse.class);
+			// test that explicit scope overrides the ScopedBy
+			per(Scope.injection).autobind().produceBy(flat).in(ScopeIsKept.class);
+		}
+	}
+
+	public static class SelectMethodFromHints {
+
+		public CharSequence fromStringAndInt(String a, Integer b) {
+			return a + b;
+		}
+
+		public CharSequence fromString(String a) {
+			return a;
+		}
+
+		public CharSequence fromDoubleAndString(double a, String b) {
+			return a + b;
+		}
+
+		public CharSequence fromStringAndLongAndInt(int c, String a, long b) {
+			return a + b + c;
+		}
+	}
+
+	public static class SelectMethodOrAndOrElse {
+
+		public boolean boundForBoolean() {
+			return true;
+		}
+
+		public boolean notBoundForBoolean() {
+			return false;
+		}
+
+		public int boundForInt() {
+			return 2;
+		}
+
+		public int alsoBoundForInt() {
+			return 3;
+		}
+
+		public final double notBound() {
+			return -1d;
+		}
+
+		public float alsoNotBound() {
+			return -2f;
+		}
+	}
+
+	public static class ScopeIsKept {
+
+		int callCount;
+
+		public byte value() {
+			return (byte) callCount++;
+		}
+	}
+
+	private final Injector context = Bootstrap.injector(
+			TestBasicAutoBindsModule.class);
+
+	@Test
+	void methodSelectionBySignatureUsingHints() {
+		assertEquals("prefix12", context.resolve(CharSequence.class));
+	}
+
+	@Test
+	void methodSelectionWithOr() {
+		assertTrue(context.resolve(boolean.class), "wrong boolean method bound");
+		assertEquals(new HashSet<>(asList(2, 3, 12)),
+				new HashSet<>(asList(context.resolve(Integer[].class))));
+		assertThrows(UnresolvableDependency.class,
+				() -> context.resolve(double.class), "should not be bound");
+		assertThrows(UnresolvableDependency.class,
+				() -> context.resolve(float.class), "should not be bound");
+	}
+
+	@Test
+	void methodScopeFromExplicitPerClause() {
+		assertEquals(0, context.resolve(byte.class).byteValue());
+		assertEquals(1, context.resolve(byte.class).byteValue());
+		assertEquals(2, context.resolve(byte.class).byteValue());
+	}
 }

--- a/test.integration/test/java/test/integration/bind/TestBasicCollectionBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicCollectionBinds.java
@@ -5,7 +5,7 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 import se.jbee.inject.lang.Cast;
 import se.jbee.inject.lang.Type;
 
@@ -40,7 +40,7 @@ class TestBasicCollectionBinds {
 
 		@Override
 		protected void bootstrap() {
-			installAll(CoreFeature.class);
+			installAll(DefaultFeature.class);
 			install(TestBasicCollectionBindsModule.class);
 		}
 	}
@@ -49,7 +49,7 @@ class TestBasicCollectionBinds {
 
 		@Override
 		protected void bootstrap() {
-			install(CoreFeature.LIST, CoreFeature.COLLECTION);
+			install(DefaultFeature.LIST, DefaultFeature.COLLECTION);
 			install(TestBasicCollectionBindsModule.class);
 		}
 	}

--- a/test.integration/test/java/test/integration/bind/TestBasicCustomAutobindBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicCustomAutobindBinds.java
@@ -6,6 +6,8 @@ import se.jbee.inject.UnresolvableDependency.NoResourceForDependency;
 import se.jbee.inject.binder.Binder;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.config.HintsBy;
+import se.jbee.inject.config.NamesBy;
 import test.integration.util.Resource;
 import test.integration.util.WebMethod;
 
@@ -16,8 +18,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static se.jbee.inject.Name.named;
 import static se.jbee.inject.Packages.packageAndSubPackagesOf;
 import static se.jbee.inject.Provider.providerTypeOf;
-import static se.jbee.inject.config.HintsBy.noParameters;
-import static se.jbee.inject.config.NamesBy.defaultName;
 import static se.jbee.inject.config.ProducesBy.allMethods;
 import static se.jbee.inject.config.ProducesBy.declaredMethods;
 import static se.jbee.inject.lang.Type.raw;
@@ -42,8 +42,9 @@ class TestBasicCustomAutobindBinds {
 					.in(this);
 			autobind() //
 					.produceBy(allMethods.annotatedWith(WebMethod.class)) //
-					.nameBy(defaultName.unlessAnnotatedWith(Resource.class)) //
-					.hintBy(noParameters.unlessAnnotatedWith(Resource.class)) //
+					.nameBy(NamesBy.annotatedWith(Resource.class, Resource::value)) //
+					.hintBy(HintsBy.instanceReference( //
+							NamesBy.annotatedWith(Resource.class, Resource::value))) //
 					.in(Implementor1.class);
 			autobind() //
 					.produceBy(allMethods.returnTypeAssignableTo(

--- a/test.integration/test/java/test/integration/bind/TestBasicCustomAutobindBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicCustomAutobindBinds.java
@@ -8,6 +8,7 @@ import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 import se.jbee.inject.config.HintsBy;
 import se.jbee.inject.config.NamesBy;
+import se.jbee.inject.config.ProducesBy;
 import test.integration.util.Resource;
 import test.integration.util.WebMethod;
 
@@ -18,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static se.jbee.inject.Name.named;
 import static se.jbee.inject.Packages.packageAndSubPackagesOf;
 import static se.jbee.inject.Provider.providerTypeOf;
-import static se.jbee.inject.config.ProducesBy.allMethods;
+import static se.jbee.inject.config.ProducesBy.OPTIMISTIC;
 import static se.jbee.inject.config.ProducesBy.declaredMethods;
 import static se.jbee.inject.lang.Type.raw;
 
@@ -38,27 +39,27 @@ class TestBasicCustomAutobindBinds {
 		@Override
 		protected void declare() {
 			autobind() //
-					.produceBy(declaredMethods) //
+					.produceBy(declaredMethods(false)) //
 					.in(this);
 			autobind() //
-					.produceBy(allMethods.annotatedWith(WebMethod.class)) //
+					.produceBy(OPTIMISTIC.annotatedWith(WebMethod.class)) //
 					.nameBy(NamesBy.annotatedWith(Resource.class, Resource::value)) //
 					.hintBy(HintsBy.instanceReference( //
 							NamesBy.annotatedWith(Resource.class, Resource::value))) //
 					.in(Implementor1.class);
 			autobind() //
-					.produceBy(allMethods.returnTypeAssignableTo(
+					.produceBy(OPTIMISTIC.returnTypeAssignableTo(
 							raw(Provider.class))) //
 					.in(Implementor2.class);
 			autobind() //
-					.produceBy(allMethods.returnTypeIn(
+					.produceBy(OPTIMISTIC.returnTypeIn(
 							packageAndSubPackagesOf(Injector.class))) //
 					.in(Implementor3.class);
 			per(Scope.application).autobind() //
-					.produceBy(declaredMethods) //
+					.produceBy(OPTIMISTIC) //
 					.in(new Implementor4(STATE));
 			per(Scope.injection).autobind() //
-					.produceBy(declaredMethods) //
+					.produceBy(OPTIMISTIC) //
 					.in(FactoryImpl.class);
 		}
 

--- a/test.integration/test/java/test/integration/bind/TestBasicCustomPrimitiveArrayBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicCustomPrimitiveArrayBinds.java
@@ -8,6 +8,7 @@ import se.jbee.inject.Supplier;
 import se.jbee.inject.bind.Bootstrapper;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.defaults.DefaultFeature;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static se.jbee.inject.Name.named;
@@ -17,7 +18,7 @@ import static se.jbee.inject.lang.Type.raw;
  * This test demonstrates how to add user defined primitive array support.
  * <p>
  * The default way however to enable primitive array support is to install
- * {@link se.jbee.inject.defaults.CoreFeature#PRIMITIVE_ARRAYS} which by default
+ * {@link DefaultFeature#PRIMITIVE_ARRAYS} which by default
  * is not installed as part of the {@link Bootstrapper#installDefaults()} as
  * it is shown in {@link TestBasicPrimitiveArrayBridgeBinds}.
  *

--- a/test.integration/test/java/test/integration/bind/TestBasicGeneratorBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicGeneratorBinds.java
@@ -4,14 +4,31 @@ import org.junit.jupiter.api.Test;
 import se.jbee.inject.Dependency;
 import se.jbee.inject.Generator;
 import se.jbee.inject.Injector;
-import se.jbee.inject.UnresolvableDependency;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.jbee.inject.Resource.resourceTypeOf;
-import static se.jbee.inject.lang.Type.raw;
 
+/**
+ * A test to demonstrate the difference between {@link se.jbee.inject.binder.Binder.TypedBinder#toGenerator(Generator)}
+ * and {@link se.jbee.inject.binder.Binder.TypedBinder#toScopedGenerator(Generator)}.
+ * <p>
+ * Usually when binding to a {@link Generator} the API will assume that the user
+ * wants the {@link Generator} to be used directly as the {@link Generator} is
+ * the user facing API to generate instances. This means the backend facing
+ * concept of the {@link se.jbee.inject.Supplier} which adds the {@link
+ * se.jbee.inject.Scope} effects within the {@link Injector} is not involved in
+ * instance creation.
+ * <p>
+ * If user just use the {@link Generator} interface because it was the more
+ * convenient way to implement their instance generation but they still want the
+ * usual instance creation process provided by a {@link se.jbee.inject.Supplier}
+ * they can use the {@link se.jbee.inject.binder.Binder.TypedBinder#toScopedGenerator(Generator)
+ * method instead.
+ */
 class TestBasicGeneratorBinds {
 
 	private static final class TestBasicGeneratorBindsModule extends BinderModule
@@ -20,23 +37,33 @@ class TestBasicGeneratorBinds {
 		@Override
 		protected void declare() {
 			bind(String.class).toGenerator(this);
+			AtomicInteger val = new AtomicInteger();
+			bind(int.class).toScopedGenerator(dep -> val.incrementAndGet());
 		}
 
 		@Override
-		public String generate(Dependency<? super String> dep)
-				throws UnresolvableDependency {
+		public String generate(Dependency<? super String> dep) {
 			return "hello world";
 		}
 	}
 
-	private final Injector injector = Bootstrap.injector(
+	private final Injector context = Bootstrap.injector(
 			TestBasicGeneratorBindsModule.class);
 
 	@Test
-	void generatorCanBePassedDirectly() {
-		assertEquals("hello world", injector.resolve(String.class));
-		assertEquals("SupplierGeneratorBridge",
-				injector.resolve(resourceTypeOf(raw(
-						String.class))).generator.getClass().getSimpleName());
+	void toGeneratorBypassesScopeEffects() {
+		assertEquals("hello world", context.resolve(String.class));
+		assertEquals("NonScopedGenerator", context.resolve(resourceTypeOf(
+				String.class)).generator.getClass().getSimpleName());
+	}
+
+	@Test
+	void toScopedGeneratorDoesNotBypassScopeEffects() {
+		assertEquals(1, context.resolve(int.class));
+		assertEquals(1, context.resolve(int.class),
+				"second time is the real test - if this is scoped this is a application singleton so the value is still 1");
+		// another way to verify it...
+		assertEquals("LazyScopedGenerator", context.resolve(resourceTypeOf(
+				int.class)).generator.getClass().getSimpleName());
 	}
 }

--- a/test.integration/test/java/test/integration/bind/TestBasicGeneratorBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicGeneratorBinds.java
@@ -8,8 +8,6 @@ import se.jbee.inject.UnresolvableDependency;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 
-import java.lang.reflect.InvocationTargetException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.jbee.inject.Resource.resourceTypeOf;
 import static se.jbee.inject.lang.Type.raw;

--- a/test.integration/test/java/test/integration/bind/TestBasicGeneratorBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicGeneratorBinds.java
@@ -8,6 +8,8 @@ import se.jbee.inject.UnresolvableDependency;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 
+import java.lang.reflect.InvocationTargetException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.jbee.inject.Resource.resourceTypeOf;
 import static se.jbee.inject.lang.Type.raw;
@@ -39,5 +41,4 @@ class TestBasicGeneratorBinds {
 				injector.resolve(resourceTypeOf(raw(
 						String.class))).generator.getClass().getSimpleName());
 	}
-
 }

--- a/test.integration/test/java/test/integration/bind/TestBasicHintsBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicHintsBinds.java
@@ -10,6 +10,7 @@ import se.jbee.inject.bootstrap.Bootstrap;
 
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.math.BigInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static se.jbee.inject.Hint.constant;
@@ -71,6 +72,11 @@ class TestBasicHintsBinds {
 			this.value = value;
 			this.sequence = sequence;
 		}
+
+		public Qux(BigInteger value, String sequence, Double number) {
+			this.value = value;
+			this.sequence = sequence + "meh";
+		}
 	}
 
 	private static class ParameterConstructorBindsModule extends BinderModule {
@@ -102,22 +108,22 @@ class TestBasicHintsBinds {
 
 	}
 
-	private final Injector injector = Bootstrap.injector(
+	private final Injector context = Bootstrap.injector(
 			ParameterConstructorBindsModule.class);
 
 	@Test
 	void classParameterIsArranged() {
-		assertNotNull(injector.resolve(Foo.class));
+		assertNotNull(context.resolve(Foo.class));
 	}
 
 	@Test
 	void typeParameterIsArranged() {
-		assertNotNull(injector.resolve(Bar.class));
+		assertNotNull(context.resolve(Bar.class));
 	}
 
 	@Test
 	void instanceParameterIsArranged() {
-		Bar bar = injector.resolve(Bar.class);
+		Bar bar = context.resolve(Bar.class);
 		assertEquals("y", bar.foo);
 	}
 
@@ -132,7 +138,7 @@ class TestBasicHintsBinds {
 	 */
 	@Test
 	void parameterAsAnotherTypeIsArranged() {
-		Qux qux = injector.resolve(Qux.class);
+		Qux qux = context.resolve(Qux.class);
 		assertEquals("y", qux.sequence);
 	}
 
@@ -141,13 +147,13 @@ class TestBasicHintsBinds {
 	 */
 	@Test
 	void constantParameterIsArranged() {
-		Qux qux = injector.resolve(Qux.class);
+		Qux qux = context.resolve(Qux.class);
 		assertEquals(1980, qux.value);
 	}
 
 	@Test
 	void reoccurringTypesAreArrangedAsOccurringAfterAnother() {
-		Baz baz = injector.resolve(Baz.class);
+		Baz baz = context.resolve(Baz.class);
 		assertEquals("y", baz.foo);
 		assertEquals("y", baz.bar, "when x alignment after another is broken");
 	}

--- a/test.integration/test/java/test/integration/bind/TestBasicHintsBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicHintsBinds.java
@@ -106,17 +106,17 @@ class TestBasicHintsBinds {
 			ParameterConstructorBindsModule.class);
 
 	@Test
-	void thatClassParameterIsArranged() {
+	void classParameterIsArranged() {
 		assertNotNull(injector.resolve(Foo.class));
 	}
 
 	@Test
-	void thatTypeParameterIsArranged() {
+	void typeParameterIsArranged() {
 		assertNotNull(injector.resolve(Bar.class));
 	}
 
 	@Test
-	void thatInstanceParameterIsArranged() {
+	void instanceParameterIsArranged() {
 		Bar bar = injector.resolve(Bar.class);
 		assertEquals("y", bar.foo);
 	}
@@ -131,29 +131,29 @@ class TestBasicHintsBinds {
 	 * 1st argument.
 	 */
 	@Test
-	void thatParameterAsAnotherTypeIsArranged() {
+	void parameterAsAnotherTypeIsArranged() {
 		Qux qux = injector.resolve(Qux.class);
 		assertEquals("y", qux.sequence);
 	}
 
 	/**
-	 * @see #thatParameterAsAnotherTypeIsArranged()
+	 * @see #parameterAsAnotherTypeIsArranged()
 	 */
 	@Test
-	void thatConstantParameterIsArranged() {
+	void constantParameterIsArranged() {
 		Qux qux = injector.resolve(Qux.class);
 		assertEquals(1980, qux.value);
 	}
 
 	@Test
-	void thatReoccuringTypesAreArrangedAsOccuringAfterAnother() {
+	void reoccurringTypesAreArrangedAsOccurringAfterAnother() {
 		Baz baz = injector.resolve(Baz.class);
 		assertEquals("y", baz.foo);
 		assertEquals("y", baz.bar, "when x alignment after another is broken");
 	}
 
 	@Test
-	void thatParametersNotArrangedThrowsException() {
+	void parametersNotArrangedThrowsException() {
 		assertThrows(InconsistentDeclaration.class,
 				() -> Bootstrap.injector(FaultyParameterConstructorBindsModule.class));
 	}

--- a/test.integration/test/java/test/integration/bind/TestBasicLoggerBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicLoggerBinds.java
@@ -5,24 +5,24 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.Installs;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
- * A test that demonstrates how install {@link CoreFeature#LOGGER} so that each
+ * A test that demonstrates how install {@link DefaultFeature#LOGGER} so that each
  * class gets its class-specific- {@link Logger} injected.
  * <p>
  * This is also meant as a template to learn how to implement a similar feature
  * for another logging framework. Just have a look at how the {@link
- * BinderModule} implementing the {@link CoreFeature#LOGGER} toggle is
+ * BinderModule} implementing the {@link DefaultFeature#LOGGER} toggle is
  * implemented.
  */
 class TestBasicLoggerBinds {
 
-	@Installs(features = CoreFeature.class, selection = "LOGGER")
+	@Installs(features = DefaultFeature.class, selection = "LOGGER")
 	private static class TestBasicLoggerBindsModule extends BinderModule {
 
 		@Override

--- a/test.integration/test/java/test/integration/bind/TestBasicMultiModuleSetupBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicMultiModuleSetupBinds.java
@@ -2,8 +2,9 @@ package test.integration.bind;
 
 import org.junit.jupiter.api.Test;
 import se.jbee.inject.DeclarationType;
+import se.jbee.inject.Env;
+import se.jbee.inject.Injector;
 import se.jbee.inject.bind.Binding;
-import se.jbee.inject.bind.Bindings;
 import se.jbee.inject.bind.Module;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
@@ -28,7 +29,6 @@ class TestBasicMultiModuleSetupBinds {
 			bind(String.class).to("2");
 			bind(Float.class).to(3.0f);
 		}
-
 	}
 
 	static class TestBasicMultiModuleSetupBindsModule2 extends BinderModule {
@@ -37,7 +37,6 @@ class TestBasicMultiModuleSetupBinds {
 		protected void declare() {
 			bind(Double.class).to(2.0);
 		}
-
 	}
 
 	static class TestBasicMultiModuleSetupBindsBundle
@@ -48,14 +47,14 @@ class TestBasicMultiModuleSetupBinds {
 			install(TestBasicMultiModuleSetupBindsModule1.class);
 			install(TestBasicMultiModuleSetupBindsModule2.class);
 		}
-
 	}
 
 	@Test
-	void thatBindingSourceReflectsTheOrigin() {
-		Binding<?>[] bindings = Bootstrap.bindings(Environment.DEFAULT,
-				TestBasicMultiModuleSetupBindsBundle.class,
-				Bindings.newBindings());
+	void bindingSourceReflectsTheOrigin() {
+		Injector context = Bootstrap.injector(Environment.DEFAULT //
+						.with(Env.GP_BIND_BINDINGS, true),
+				TestBasicMultiModuleSetupBindsBundle.class);
+		Binding<?>[] bindings = context.resolve(Binding[].class);
 
 		assertBinding(TestBasicMultiModuleSetupBindsModule1.class, 1, EXPLICIT,
 				forType(Integer.class, bindings));

--- a/test.integration/test/java/test/integration/bind/TestBasicMultibindBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicMultibindBinds.java
@@ -6,7 +6,7 @@ import se.jbee.inject.Name;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 import se.jbee.inject.lang.Type;
 
 import java.util.List;
@@ -73,8 +73,8 @@ class TestBasicMultibindBinds {
 		protected void bootstrap() {
 			install(TestBasicMultibindBindsModule1.class);
 			install(TestBasicMultibindBindsModule2.class);
-			install(CoreFeature.SET);
-			install(CoreFeature.LIST);
+			install(DefaultFeature.SET);
+			install(DefaultFeature.LIST);
 		}
 	}
 

--- a/test.integration/test/java/test/integration/bind/TestBasicPrimitiveArrayBridgeBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicPrimitiveArrayBridgeBinds.java
@@ -5,7 +5,7 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.Installs;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.jbee.inject.Name.named;
 
 /**
- * The test demonstrates the {@link CoreFeature#PRIMITIVE_ARRAYS} that installs
+ * The test demonstrates the {@link DefaultFeature#PRIMITIVE_ARRAYS} that installs
  * a bridge between wrapper arrays and their primitive counterparts so that
  * values of wrappers (and their 1-dimensional array types) can be resolved as
  * primitive arrays as well.
@@ -24,7 +24,7 @@ import static se.jbee.inject.Name.named;
  */
 class TestBasicPrimitiveArrayBridgeBinds {
 
-	@Installs(features = CoreFeature.class, selection = "PRIMITIVE_ARRAYS")
+	@Installs(features = DefaultFeature.class, selection = "PRIMITIVE_ARRAYS")
 	private static class TestBasicCustomPrimitiveArrayBindsModule
 			extends BinderModule {
 

--- a/test.integration/test/java/test/integration/bind/TestBasicPrimitiveValueBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicPrimitiveValueBinds.java
@@ -5,6 +5,7 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.UnresolvableDependency.NoResourceForDependency;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.defaults.DefaultFeature;
 import se.jbee.inject.lang.Type;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -84,7 +85,7 @@ class TestBasicPrimitiveValueBinds {
 
 	/**
 	 * To allow such a automatic conversion a bridge can be installed using
-	 * {@link se.jbee.inject.defaults.CoreFeature#PRIMITIVE_ARRAYS}. By default
+	 * {@link DefaultFeature#PRIMITIVE_ARRAYS}. By default
 	 * however this is not installed so the below call fails.
 	 */
 	@Test

--- a/test.integration/test/java/test/integration/bind/TestBasicScopedBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicScopedBinds.java
@@ -45,8 +45,8 @@ class TestBasicScopedBinds {
 	void injectingAnInjectionScopedInstanceIntoAppScopedInstanceThrowsAnException() {
 		Exception ex = assertThrows(UnstableDependency.class, () -> context.resolve(Foo.class));
 		assertEquals("Unstable dependency injection\n"
-				+ "\t  of: test.integration.bind.TestBasicScopedBinds.Bar  in * into * => *  scoped injection\n"
-				+ "\tinto: test.integration.bind.TestBasicScopedBinds.Foo  in * into * => *  scoped application",
+				+ "\t  of: test.integration.bind.TestBasicScopedBinds.Bar  scoped injection\n"
+				+ "\tinto: test.integration.bind.TestBasicScopedBinds.Foo  scoped application",
 				ex.getMessage());
 	}
 }

--- a/test.integration/test/java/test/integration/bind/TestBasicScopedBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicScopedBinds.java
@@ -45,8 +45,8 @@ class TestBasicScopedBinds {
 	void injectingAnInjectionScopedInstanceIntoAppScopedInstanceThrowsAnException() {
 		Exception ex = assertThrows(UnstableDependency.class, () -> context.resolve(Foo.class));
 		assertEquals("Unstable dependency injection\n"
-				+ "\t  of: test.integration.bind.TestBasicScopedBinds.Bar  scoped injection\n"
-				+ "\tinto: test.integration.bind.TestBasicScopedBinds.Foo  scoped application",
+				+ "\t  of: test.integration.bind.TestBasicScopedBinds.Bar scoped injection\n"
+				+ "\tinto: test.integration.bind.TestBasicScopedBinds.Foo scoped application",
 				ex.getMessage());
 	}
 }

--- a/test.integration/test/java/test/integration/bind/TestBasicSuperbindBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicSuperbindBinds.java
@@ -9,14 +9,14 @@ import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
- * The tests demonstrates the meaning of a {@link Binder#autobind(Class)} call.
+ * The tests demonstrates the meaning of a {@link Binder#superbind(Class)} call.
  * That will create multiple binds, one each for the type and all its
  * super-classes and -interfaces. All of them are bound to the same to-clause,
  * hence share the same {@link Supplier} (in the end all to-clauses become one).
@@ -28,44 +28,39 @@ import static se.jbee.inject.lang.Type.raw;
  * setup. But in some cases an instance should serve as many different
  * interfaces all implemented by it (e.g. a class implementing a couple of
  * single service interfaces).
- *
- * @author Jan Bernitt (jan@jbee.se)
  */
-class TestBasicAutobindBinds {
+class TestBasicSuperbindBinds {
 
-	static class TestBasicAutobindBindsModule extends BinderModule {
+	static class TestBasicSuperbindBindsModule extends BinderModule {
 
 		@Override
 		protected void declare() {
-			autobind(Integer.class).to(42);
-			autobind(raw(List.class).parametized(String.class)).to(
-					Arrays.asList(new String[] {}));
+			superbind(Integer.class).to(42);
+			superbind(raw(List.class).parametized(String.class)).to(emptyList());
 		}
-
 	}
 
 	private final Injector injector = Bootstrap.injector(
-			TestBasicAutobindBindsModule.class);
+			TestBasicSuperbindBindsModule.class);
 
 	@Test
-	void thatTheAutoboundTypeItselfIsBound() {
+	void superbindTypeItselfIsBound() {
 		assertEquals(42, injector.resolve(Integer.class).intValue());
 	}
 
 	@Test
-	void thatDirectSuperclassOfAutoboundTypeIsBound() {
+	void directSuperclassOfSuperbindTypeIsBound() {
 		assertEquals(42, injector.resolve(Number.class).intValue());
 	}
 
 	@Test
-	void thatSuperinterfaceOfAutoboundTypeIsBound() {
+	void superInterfaceOfSuperbindTypeIsBound() {
 		assertEquals(42, injector.resolve(Serializable.class));
 	}
 
 	@Test
-	void thatParametizedSuperinterfaceOfAutoboundTypeIsBound() {
+	void parametrizedSuperInterfaceOfSuperbindTypeIsBound() {
 		assertEquals(42, injector.resolve(
 				raw(Comparable.class).parametized(Integer.class)));
 	}
-
 }

--- a/test.integration/test/java/test/integration/bind/TestExampleAnnotatedScopeBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleAnnotatedScopeBinds.java
@@ -28,7 +28,7 @@ class TestExampleAnnotatedScopeBinds {
 	private static class TestExampleAnnotatedScopeBindsModule extends BinderModule {
 
 		@Override
-		protected Env configure(Env env) {
+		public Env configure(Env env) {
 			return Environment.override(env) //
 					.with(ScopesBy.class, //
 							ScopesBy.annotatedWith(Scoped.class, Scoped::value));

--- a/test.integration/test/java/test/integration/bind/TestExampleAnnotatedScopeBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleAnnotatedScopeBinds.java
@@ -30,8 +30,8 @@ class TestExampleAnnotatedScopeBinds {
 		@Override
 		protected Env configure(Env env) {
 			return Environment.override(env) //
-					.with(ScopesBy.class, ScopesBy.alwaysDefault //
-							.unlessAnnotatedWith(Scoped.class));
+					.with(ScopesBy.class, //
+							ScopesBy.annotatedWith(Scoped.class, Scoped::value));
 		}
 
 		@Override

--- a/test.integration/test/java/test/integration/bind/TestExampleAnnotationGuidedBindingBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleAnnotationGuidedBindingBinds.java
@@ -76,7 +76,7 @@ class TestExampleAnnotationGuidedBindingBinds {
 		protected void declare(Class<?> annotated) {
 			per(Scope.application)
 					.withIndirectAccess() // withIndirectAccess just used as an example (not needed)
-					.autobind(annotated).toConstructor();
+					.superbind(annotated).toConstructor();
 		}
 	}
 

--- a/test.integration/test/java/test/integration/bind/TestExampleDependencyAsHintBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleDependencyAsHintBinds.java
@@ -7,7 +7,7 @@ import se.jbee.inject.Instance;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.Installs;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 
 import java.util.logging.Logger;
 
@@ -27,7 +27,7 @@ import static se.jbee.inject.Dependency.dependency;
  */
 class TestExampleDependencyAsHintBinds {
 
-	@Installs(features = CoreFeature.class, selection = "LOGGER")
+	@Installs(features = DefaultFeature.class, selection = "LOGGER")
 	private static class TestExampleDependencyAsHintBindsModule
 			extends BinderModule {
 

--- a/test.integration/test/java/test/integration/bind/TestExampleRobotLegsProblemBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleRobotLegsProblemBinds.java
@@ -9,7 +9,6 @@ import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static se.jbee.inject.Instance.anyOf;
 
 /**
  * This tests demonstrates 2 different ways to solve the somewhat famous "Robot

--- a/test.integration/test/java/test/integration/bind/TestExampleRobotLegsProblemBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleRobotLegsProblemBinds.java
@@ -9,6 +9,7 @@ import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static se.jbee.inject.Instance.anyOf;
 
 /**
  * This tests demonstrates 2 different ways to solve the somewhat famous "Robot
@@ -90,9 +91,9 @@ class TestExampleRobotLegsProblemBinds {
 
 		@Override
 		protected void declare() {
-			per(Scope.targetInstance).construct(Foot.class);
 			bind(left, Leg.class).toConstructor();
 			bind(right, Leg.class).toConstructor();
+			per(Scope.targetInstance).construct(Foot.class);
 		}
 	}
 
@@ -109,9 +110,9 @@ class TestExampleRobotLegsProblemBinds {
 	}
 
 	private static void assertRobotHasDifferentLegsWithDifferentFeet(
-			Injector injector) {
-		Leg leftLeg = injector.resolve(left, Leg.class);
-		Leg rightLeg = injector.resolve(right, Leg.class);
+			Injector context) {
+		Leg leftLeg = context.resolve(left, Leg.class);
+		Leg rightLeg = context.resolve(right, Leg.class);
 		assertNotSame(rightLeg, leftLeg, "same leg");
 		assertNotSame(rightLeg.foot, leftLeg.foot, "same foot");
 	}

--- a/test.integration/test/java/test/integration/bind/TestExampleStateDependentInjectionBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleStateDependentInjectionBinds.java
@@ -7,7 +7,7 @@ import se.jbee.inject.binder.Binder.RootBinder;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 import se.jbee.inject.lang.Type;
 import test.integration.util.Resource;
 
@@ -264,7 +264,7 @@ class TestExampleStateDependentInjectionBinds {
 		@Override
 		protected void bootstrap() {
 			install(Solution1.class);
-			install(CoreFeature.PROVIDER);
+			install(DefaultFeature.PROVIDER);
 		}
 	}
 

--- a/test.integration/test/java/test/integration/bind/TestExampleStateDependentInjectionBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleStateDependentInjectionBinds.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static se.jbee.inject.Dependency.dependency;
 import static se.jbee.inject.Name.named;
 import static se.jbee.inject.Provider.providerTypeOf;
-import static se.jbee.inject.config.ProducesBy.allMethods;
+import static se.jbee.inject.config.ProducesBy.OPTIMISTIC;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -195,7 +195,7 @@ class TestExampleStateDependentInjectionBinds {
 
 			// the below is just *a* example - it is just important to provide the 'value' per injection
 			per(Scope.injection).autobind() //
-					.produceBy(allMethods.returnTypeAssignableTo(
+					.produceBy(OPTIMISTIC.returnTypeAssignableTo(
 							raw(ValidationStrength.class))) //
 					.in(StatefulObject.class);
 		}
@@ -225,7 +225,7 @@ class TestExampleStateDependentInjectionBinds {
 
 			// the below is just *a* example - it is just important to provide the 'value' per injection
 			per(Scope.injection).autobind() //
-					.produceBy(allMethods.returnTypeAssignableTo(
+					.produceBy(OPTIMISTIC.returnTypeAssignableTo(
 							raw(ValidationStrength.class))) //
 					.in(StatefulObject.class);
 		}
@@ -249,7 +249,7 @@ class TestExampleStateDependentInjectionBinds {
 			// the below is just *a* example - it is just important to provide the 'value' per injection
 			per(Scope.injection).autobind() //
 					.produceBy(
-							allMethods.returnTypeAssignableTo(raw(int.class))) //
+							OPTIMISTIC.returnTypeAssignableTo(raw(int.class))) //
 					.nameBy(NamesBy.annotatedWith(Resource.class, Resource::value)) //
 					.hintBy(HintsBy.instanceReference( //
 							NamesBy.annotatedWith(Resource.class, Resource::value))) //

--- a/test.integration/test/java/test/integration/bind/TestExampleStateDependentInjectionBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestExampleStateDependentInjectionBinds.java
@@ -7,6 +7,8 @@ import se.jbee.inject.binder.Binder.RootBinder;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
 import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.config.HintsBy;
+import se.jbee.inject.config.NamesBy;
 import se.jbee.inject.defaults.DefaultFeature;
 import se.jbee.inject.lang.Type;
 import test.integration.util.Resource;
@@ -16,8 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static se.jbee.inject.Dependency.dependency;
 import static se.jbee.inject.Name.named;
 import static se.jbee.inject.Provider.providerTypeOf;
-import static se.jbee.inject.config.HintsBy.noParameters;
-import static se.jbee.inject.config.NamesBy.defaultName;
 import static se.jbee.inject.config.ProducesBy.allMethods;
 import static se.jbee.inject.lang.Type.raw;
 
@@ -48,7 +48,8 @@ import static se.jbee.inject.lang.Type.raw;
  */
 class TestExampleStateDependentInjectionBinds {
 
-	@FunctionalInterface interface Validator {
+	@FunctionalInterface
+	interface Validator {
 
 		boolean valid(String input);
 	}
@@ -63,7 +64,6 @@ class TestExampleStateDependentInjectionBinds {
 		public boolean valid(String input) {
 			return true; // just for testing
 		}
-
 	}
 
 	public static class Strict implements Validator {
@@ -72,7 +72,6 @@ class TestExampleStateDependentInjectionBinds {
 		public boolean valid(String input) {
 			return false; // just for testing
 		}
-
 	}
 
 	public static class StatefulObject {
@@ -103,7 +102,6 @@ class TestExampleStateDependentInjectionBinds {
 		public void setNumber(Integer number) {
 			this.number = number;
 		}
-
 	}
 
 	/* Module and Bundle code to setup scenario */
@@ -252,8 +250,9 @@ class TestExampleStateDependentInjectionBinds {
 			per(Scope.injection).autobind() //
 					.produceBy(
 							allMethods.returnTypeAssignableTo(raw(int.class))) //
-					.nameBy(defaultName.unlessAnnotatedWith(Resource.class)) //
-					.hintBy(noParameters.unlessAnnotatedWith(Resource.class)) //
+					.nameBy(NamesBy.annotatedWith(Resource.class, Resource::value)) //
+					.hintBy(HintsBy.instanceReference( //
+							NamesBy.annotatedWith(Resource.class, Resource::value))) //
 					.in(StatefulObject.class);
 		}
 
@@ -326,6 +325,7 @@ class TestExampleStateDependentInjectionBinds {
 		StatefulObject state = context.resolve(StatefulObject.class);
 		state.setNumber(actualValue);
 		String v = context.resolve(String.class);
-		assertTrue(v.endsWith(ending));
+		assertTrue(v.endsWith(ending),
+				"assumed to end with " + ending + " but was " + v);
 	}
 }

--- a/test.integration/test/java/test/integration/bind/TestFeatureAnnotatedWithBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureAnnotatedWithBinds.java
@@ -9,6 +9,7 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 import se.jbee.inject.bootstrap.Environment;
+import se.jbee.inject.config.SharesBy;
 
 import java.lang.annotation.*;
 import java.lang.reflect.AnnotatedElement;
@@ -20,7 +21,6 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static se.jbee.inject.config.ProducesBy.OPTIMISTIC;
-import static se.jbee.inject.config.SharesBy.declaredFields;
 
 class TestFeatureAnnotatedWithBinds {
 
@@ -88,7 +88,7 @@ class TestFeatureAnnotatedWithBinds {
 			bind(Service.class).to(ServiceImpl.class);
 			autobind() //
 					.produceBy(OPTIMISTIC.annotatedWith(Marker.class)) //
-					.shareBy(declaredFields.annotatedWith(Marker.class)) //
+					.shareBy(SharesBy.OPTIMISTIC.annotatedWith(Marker.class)) //
 					.in(this);
 		}
 

--- a/test.integration/test/java/test/integration/bind/TestFeatureAnnotatedWithBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureAnnotatedWithBinds.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static se.jbee.inject.config.ProducesBy.declaredMethods;
+import static se.jbee.inject.config.ProducesBy.OPTIMISTIC;
 import static se.jbee.inject.config.SharesBy.declaredFields;
 
 class TestFeatureAnnotatedWithBinds {
@@ -87,7 +87,7 @@ class TestFeatureAnnotatedWithBinds {
 			bind(Bean.class).toConstructor();
 			bind(Service.class).to(ServiceImpl.class);
 			autobind() //
-					.produceBy(declaredMethods.annotatedWith(Marker.class)) //
+					.produceBy(OPTIMISTIC.annotatedWith(Marker.class)) //
 					.shareBy(declaredFields.annotatedWith(Marker.class)) //
 					.in(this);
 		}

--- a/test.integration/test/java/test/integration/bind/TestFeatureBootstrapper.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureBootstrapper.java
@@ -7,6 +7,7 @@ import se.jbee.inject.UnresolvableDependency.DependencyCycle;
 import se.jbee.inject.bind.Bundle;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
+import se.jbee.inject.binder.Installs;
 import se.jbee.inject.bootstrap.Bootstrap;
 import se.jbee.inject.bootstrap.Environment;
 import se.jbee.inject.config.ConstructsBy;
@@ -21,7 +22,7 @@ import java.time.Duration;
 import static org.junit.jupiter.api.Assertions.*;
 import static se.jbee.inject.Hint.relativeReferenceTo;
 import static se.jbee.inject.Name.named;
-import static se.jbee.inject.config.ConstructsBy.common;
+import static se.jbee.inject.config.ConstructsBy.OPTIMISTIC;
 import static se.jbee.inject.lang.Type.raw;
 
 /**
@@ -166,22 +167,13 @@ class TestFeatureBootstrapper {
 		}
 	}
 
-	private static class CustomConstructorSelectionStrategyBundle
-			extends BootstrapperBundle {
-
-		@Override
-		protected void bootstrap() {
-			install(DefaultScopes.class);
-			install(CustomConstructorSelectionStrategyModule.class);
-		}
-	}
-
 	@Target(ElementType.CONSTRUCTOR)
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface ConstructFrom {
 
 	}
 
+	@Installs(bundles = DefaultScopes.class)
 	private static class CustomConstructorSelectionStrategyModule
 			extends BinderModule {
 
@@ -189,7 +181,7 @@ class TestFeatureBootstrapper {
 		protected Env configure(Env env) {
 			return Environment.override(env) //
 					.with(ConstructsBy.class,
-							common.annotatedWith(ConstructFrom.class));
+							OPTIMISTIC.annotatedWith(ConstructFrom.class));
 		}
 
 		@Override
@@ -210,7 +202,7 @@ class TestFeatureBootstrapper {
 
 		}
 
-		public D() {
+		public D(Integer a, Double b) {
 			this("would be picked normally");
 		}
 	}
@@ -276,7 +268,7 @@ class TestFeatureBootstrapper {
 	@Test
 	void customConstructorSelectionStrategyIsUsedToPickConstructor() {
 		Injector injector = Bootstrap.injector(
-				CustomConstructorSelectionStrategyBundle.class);
+				CustomConstructorSelectionStrategyModule.class);
 		assertEquals("will be passed to D", injector.resolve(D.class).s);
 	}
 

--- a/test.integration/test/java/test/integration/bind/TestFeatureBootstrapper.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureBootstrapper.java
@@ -75,9 +75,9 @@ class TestFeatureBootstrapper {
 		protected void declare() {
 			asDefault().bind(Number.class).to(7);
 			asDefault().bind(Integer.class).to(11);
-			autobind(Integer.class).to(2);
-			autobind(Float.class).to(4f);
-			autobind(Double.class).to(42d);
+			superbind(Integer.class).to(2);
+			superbind(Float.class).to(4f);
+			superbind(Double.class).to(42d);
 			bind(Number.class).to(6);
 		}
 	}
@@ -239,7 +239,7 @@ class TestFeatureBootstrapper {
 	}
 
 	/**
-	 * In the example {@link Number} is {@link DeclarationType#AUTO} bound for
+	 * In the example {@link Number} is {@link DeclarationType#SUPER} bound for
 	 * {@link Integer} and {@link Float} but an {@link DeclarationType#EXPLICIT}
 	 * bind done overrides these automatic binds. They are removed and no
 	 * {@link Generator} is created for them.

--- a/test.integration/test/java/test/integration/bind/TestFeatureBootstrapper.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureBootstrapper.java
@@ -178,7 +178,7 @@ class TestFeatureBootstrapper {
 			extends BinderModule {
 
 		@Override
-		protected Env configure(Env env) {
+		public Env configure(Env env) {
 			return Environment.override(env) //
 					.with(ConstructsBy.class,
 							OPTIMISTIC.annotatedWith(ConstructFrom.class));

--- a/test.integration/test/java/test/integration/bind/TestFeatureConnectorBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureConnectorBinds.java
@@ -8,6 +8,7 @@ import se.jbee.inject.binder.BinderModuleWith;
 import se.jbee.inject.bootstrap.Bootstrap;
 import se.jbee.inject.bootstrap.Environment;
 import se.jbee.inject.config.Connector;
+import se.jbee.inject.config.ProducesBy;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -20,7 +21,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 import static se.jbee.inject.Name.named;
-import static se.jbee.inject.config.ProducesBy.allMethods;
 
 /**
  * This test demonstrates the basic feature of dynamically connection methods
@@ -81,7 +81,7 @@ class TestFeatureConnectorBinds {
 		protected void declare(Connector verifier) {
 			// the marking as "my-linker"
 			injectingInto(named("marked"), Bean.class) //
-					.connect(allMethods.annotatedWith(Marked.class)) //
+					.connect(ProducesBy.OPTIMISTIC.annotatedWith(Marked.class)) //
 					.in(Bean.class) //
 					.to("my-linker");
 

--- a/test.integration/test/java/test/integration/bind/TestFeatureIndirectAccessOnlyBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureIndirectAccessOnlyBinds.java
@@ -78,7 +78,7 @@ class TestFeatureIndirectAccessOnlyBinds {
 			withIndirectAccess().bind(Serializable.class).to("42");
 			withIndirectAccess().bind(Abstraction.class).to(
 					Implementation.class);
-			withIndirectAccess().autobind(
+			withIndirectAccess().superbind(
 					Implementation2.class).toConstructor();
 			construct(ValidReceiver.class);
 			construct(InvalidReceiver.class);

--- a/test.integration/test/java/test/integration/bind/TestFeatureObtainableBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureObtainableBinds.java
@@ -84,7 +84,7 @@ class TestFeatureObtainableBinds {
 				() -> box.orElseThrow());
 		assertEquals(
 				"No matching resource found.\n"
-						+ "\t dependency: java.lang.Integer *\n"
+						+ "\t dependency: java.lang.Integer\n"
 						+ "\tavailable are (for same raw type): none\n\t",
 				ex.getMessage());
 	}

--- a/test.integration/test/java/test/integration/bind/TestFeatureObtainableBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureObtainableBinds.java
@@ -84,7 +84,7 @@ class TestFeatureObtainableBinds {
 				() -> box.orElseThrow());
 		assertEquals(
 				"No matching resource found.\n"
-						+ "\t dependency: java.lang.Integer\n"
+						+ "\t dependency: java.lang.Integer *\n"
 						+ "\tavailable are (for same raw type): none\n\t",
 				ex.getMessage());
 	}

--- a/test.integration/test/java/test/integration/bind/TestFeatureOptimisticConstructorBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureOptimisticConstructorBinds.java
@@ -1,0 +1,95 @@
+package test.integration.bind;
+
+import org.junit.jupiter.api.Test;
+import se.jbee.inject.Injector;
+import se.jbee.inject.binder.BinderModule;
+import se.jbee.inject.bootstrap.Bootstrap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static se.jbee.inject.lang.Type.raw;
+
+/**
+ * This tests the behaviour of the {@link se.jbee.inject.config.ConstructsBy#OPTIMISTIC}
+ * strategy.
+ *
+ * @see TestBasicHintsBinds for testing of the strategy involving {@link
+ * se.jbee.inject.Hint}s.
+ */
+class TestFeatureOptimisticConstructorBinds {
+
+	public static class IllegalSelfReference {
+
+		public IllegalSelfReference(IllegalSelfReference endlessLoop, String another) {
+			// such a constructor would most likely cause an endless loop
+			// so it is ignored
+			fail("should not be used even though it has more parameters");
+		}
+
+		public IllegalSelfReference(String justOne) {
+			// this is ok so this is the constructor we want to pick
+		}
+	}
+
+	public static class LegalSelfReference<T> {
+
+		public LegalSelfReference(LegalSelfReference<String> other) {
+
+		}
+	}
+
+	public static class PublicOverPrivate {
+
+		final String origin;
+
+		public PublicOverPrivate() {
+			this("public");
+		}
+
+		private PublicOverPrivate(String value) {
+			this.origin = value;
+		}
+
+		protected PublicOverPrivate(Integer a, Double b) {
+			this("protected");
+		}
+
+		PublicOverPrivate(String value, Float f) {
+			this("protected " + value);
+		}
+	}
+
+	private static class TestFeatureOptimisticConstructorBindsModule extends
+			BinderModule {
+
+		@Override
+		protected void declare() {
+			bind(String.class).to("some value");
+			construct(IllegalSelfReference.class);
+
+			construct(LegalSelfReference.class);
+			bind(raw(LegalSelfReference.class).parametized(String.class))
+					.to(new LegalSelfReference<>(null));
+
+			construct(PublicOverPrivate.class);
+		}
+	}
+
+	private final Injector context = Bootstrap.injector(
+			TestFeatureOptimisticConstructorBindsModule.class);
+
+	@Test
+	void constructorsWithParametersOfSameTypeAreIgnored() {
+		assertNotNull(context.resolve(IllegalSelfReference.class));
+	}
+
+	@Test
+	void constructorsWithParametersOfSameTypeWithGenericsAreNotIgnored() {
+		assertNotNull(context.resolve(
+				raw(LegalSelfReference.class).parametized(Integer.class)));
+	}
+
+	@Test
+	void mostVisibleConstructorWinsOverMostParameterConstructor() {
+		assertEquals("public", context.resolve(PublicOverPrivate.class).origin);
+	}
+}

--- a/test.integration/test/java/test/integration/bind/TestFeatureOptionalBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureOptionalBinds.java
@@ -5,7 +5,7 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.Installs;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 
 import java.util.Optional;
 
@@ -20,7 +20,7 @@ import static se.jbee.inject.lang.Type.raw;
  */
 class TestFeatureOptionalBinds {
 
-	@Installs(features = CoreFeature.class, selection = "OPTIONAL")
+	@Installs(features = DefaultFeature.class, selection = "OPTIONAL")
 	private static final class TestOptionalBindsModule extends BinderModule {
 
 		@Override

--- a/test.integration/test/java/test/integration/bind/TestFeatureOptionalBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureOptionalBinds.java
@@ -25,7 +25,7 @@ class TestFeatureOptionalBinds {
 
 		@Override
 		protected void declare() {
-			autobind(int.class).to(5);
+			superbind(int.class).to(5);
 			bind(String.class).to("foo");
 		}
 

--- a/test.integration/test/java/test/integration/bind/TestFeatureProviderBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureProviderBinds.java
@@ -158,8 +158,8 @@ class TestFeatureProviderBinds {
 		Exception ex = assertThrows(UnstableDependency.class,
 				() -> context.resolve(FaultyStateConsumer.class));
 		assertEquals("Unstable dependency injection" +
-						"\n" + "\t  of: test.integration.bind.TestFeatureProviderBinds.DynamicState  scoped injection" +
-						"\n" + "\tinto: test.integration.bind.TestFeatureProviderBinds.FaultyStateConsumer  scoped application",
+						"\n" + "\t  of: test.integration.bind.TestFeatureProviderBinds.DynamicState scoped injection" +
+						"\n" + "\tinto: test.integration.bind.TestFeatureProviderBinds.FaultyStateConsumer scoped application",
 				ex.getMessage());
 	}
 

--- a/test.integration/test/java/test/integration/bind/TestFeatureProviderBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureProviderBinds.java
@@ -6,7 +6,7 @@ import se.jbee.inject.UnresolvableDependency.UnstableDependency;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.Installs;
 import se.jbee.inject.bootstrap.Bootstrap;
-import se.jbee.inject.defaults.CoreFeature;
+import se.jbee.inject.defaults.DefaultFeature;
 import se.jbee.inject.lang.Type;
 
 import java.util.HashSet;
@@ -45,7 +45,7 @@ import static se.jbee.inject.lang.Type.raw;
  * <p>
  * The {@link Provider} can then be used to overcome the limitations and allow
  * injecting unstable dependencies into stable ones. By default this feature
- * is not installed. To enable it install {@link CoreFeature#PROVIDER}.
+ * is not installed. To enable it install {@link DefaultFeature#PROVIDER}.
  */
 class TestFeatureProviderBinds {
 
@@ -57,7 +57,7 @@ class TestFeatureProviderBinds {
 	static final Instance<WorkingStateConsumer> B = instance(named("B"),
 			raw(WorkingStateConsumer.class));
 
-	@Installs(features = CoreFeature.class)
+	@Installs(features = DefaultFeature.class)
 	private static class TestFeatureProviderBindsModule extends BinderModule {
 
 		@Override
@@ -158,8 +158,8 @@ class TestFeatureProviderBinds {
 		Exception ex = assertThrows(UnstableDependency.class,
 				() -> context.resolve(FaultyStateConsumer.class));
 		assertEquals("Unstable dependency injection" +
-						"\n" + "\t  of: test.integration.bind.TestFeatureProviderBinds.DynamicState  in * into * => *  scoped injection" +
-						"\n" + "\tinto: test.integration.bind.TestFeatureProviderBinds.FaultyStateConsumer  in * into * => *  scoped application",
+						"\n" + "\t  of: test.integration.bind.TestFeatureProviderBinds.DynamicState  scoped injection" +
+						"\n" + "\tinto: test.integration.bind.TestFeatureProviderBinds.FaultyStateConsumer  scoped application",
 				ex.getMessage());
 	}
 

--- a/test.integration/test/java/test/integration/bind/TestFeatureSelfInjectionBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureSelfInjectionBinds.java
@@ -1,7 +1,10 @@
 package test.integration.bind;
 
 import org.junit.jupiter.api.Test;
-import se.jbee.inject.*;
+import se.jbee.inject.Dependency;
+import se.jbee.inject.Injector;
+import se.jbee.inject.Name;
+import se.jbee.inject.Scope;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 import se.jbee.inject.lang.Type;

--- a/test.integration/test/java/test/integration/bind/TestFeatureSelfInjectionBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureSelfInjectionBinds.java
@@ -1,0 +1,238 @@
+package test.integration.bind;
+
+import org.junit.jupiter.api.Test;
+import se.jbee.inject.*;
+import se.jbee.inject.binder.BinderModule;
+import se.jbee.inject.bootstrap.Bootstrap;
+import se.jbee.inject.lang.Type;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static se.jbee.inject.Dependency.dependency;
+import static se.jbee.inject.Instance.anyOf;
+import static se.jbee.inject.Instance.instance;
+import static se.jbee.inject.Name.named;
+import static se.jbee.inject.lang.Cast.listTypeOf;
+import static se.jbee.inject.lang.Type.raw;
+
+/**
+ * Test the feature {@link se.jbee.inject.defaults.DefaultFeature#SELF} which
+ * allows to inject the {@link Name} or {@link Type} or {@link Instance} that
+ * the created instance represents within the {@link Injector} context.
+ * <p>
+ * This allows to get hold of the instance's {@link Name} and full generic
+ * {@link Type}.
+ * <p>
+ * It is also possible to inject the full {@link Dependency} that caused the
+ * creation of an instance.
+ * <p>
+ * All this information can be extracted from the {@link Dependency} itself that
+ * resolves the {@link Name}, {@link Type}, {@link Instance} or {@link
+ * Dependency} value.
+ * <p>
+ * Without question this feature is most useful in building more powerful
+ * features on top of others. Within actual application code this might appear
+ * useful but should be used with caution as these types of information are
+ * specific to dependency injection context and should not exist directly as an
+ * application level concept.
+ */
+class TestFeatureSelfInjectionBinds {
+
+	public static class Foo<T> {
+
+		final Name actualName;
+		final Type<? extends Foo<T>> actualType;
+		final Instance<? extends Foo<T>> actualInstance;
+		final Dependency<? extends Foo<T>> actualDependency;
+
+		public Foo(Type<? extends Foo<T>> actualType, Name actualName,
+				Instance<? extends Foo<T>> actualInstance,
+				Dependency<? extends Foo<T>> actualDependency) {
+			this.actualType = actualType;
+			this.actualName = actualName;
+			this.actualInstance = actualInstance;
+			this.actualDependency = actualDependency;
+		}
+	}
+
+	public static class SuperFoo<T> extends Foo<T> {
+
+		final Foo<String> innerFoo;
+
+		public SuperFoo(Foo<String> innerFoo, Name actualName,
+				Type<? extends SuperFoo<T>> actualType,
+				Instance<? extends SuperFoo<T>> actualInstance,
+				Dependency<? extends SuperFoo<T>> actualDependency) {
+			super(actualType, actualName, actualInstance, actualDependency);
+			this.innerFoo = innerFoo;
+		}
+	}
+
+	public static class Bar {
+
+		final Foo<List<Integer>> foo;
+		final SuperFoo<Double> superFoo;
+
+		public Bar(Foo<List<Integer>> foo, SuperFoo<Double> superFoo) {
+			this.foo = foo;
+			this.superFoo = superFoo;
+		}
+	}
+
+	public static class Que extends Foo<BigInteger> {
+
+		final Foo<?> genericFoo;
+
+		public Que(Foo<?> genericFoo, Type<Que> actualType,
+				Name actualName, Instance<Que> actualInstance,
+				Dependency<Que> actualDependency) {
+			super(actualType, actualName, actualInstance, actualDependency);
+			this.genericFoo = genericFoo;
+		}
+	}
+
+	/**
+	 * The specific binds done here are less important.
+	 * They should just create different scenarios that can be tested.
+	 */
+	private static class TestFeatureSelfInjectionBindsModule extends
+			BinderModule {
+
+		@Override
+		protected void declare() {
+			// make Foo and SuperFoo be created per instance
+			per(Scope.dependencyInstance).bind(Name.ANY, Foo.class).toConstructor();
+			per(Scope.dependencyInstance).bind(Name.ANY, SuperFoo.class).toConstructor();
+
+			// give the Foo in Bar a name we can check for
+			injectingInto(Bar.class).construct(named("myNameNested"), Foo.class);
+
+			// give SuperFoo in Bar a name using a Hint
+			bind(Bar.class).toConstructor(
+					instance(named("special"), raw(SuperFoo.class)).asHint());
+
+			injectingInto(SuperFoo.class).bind(Foo.class).to(named("inner"), Foo.class);
+
+			construct(Que.class);
+			bind(named("x"), Que.class).toConstructor(instance(named("y"),
+					raw(Foo.class).parametized(String.class)).asHint());
+		}
+	}
+
+	private final Injector context = Bootstrap.injector(
+			TestFeatureSelfInjectionBindsModule.class);
+
+	/*
+	Type
+	 */
+
+	@Test
+	void actualTypeFromAdHoc() {
+		Foo<?> fooString = context.resolve(
+				raw(Foo.class).parametized(String.class));
+		assertSame(String.class, fooString.actualType.parameter(0).rawType);
+	}
+
+	@Test
+	void actualTypeFromParameterNestedFlatType() {
+		assertEquals(listTypeOf(Integer.class),
+				context.resolve(Bar.class).foo.actualType.parameter(0));
+	}
+
+	@Test
+	void actualTypeFromParameterNestedDeepType() {
+		assertEquals(raw(SuperFoo.class).parametized(Double.class),
+				context.resolve(Bar.class).superFoo.actualType);
+	}
+
+	@Test
+	void actualTypeFromParameterNestedFlatWildcardType() {
+		assertEquals(raw(Foo.class).parametizedAsUpperBounds(),
+				context.resolve(Que.class).genericFoo.actualType);
+	}
+
+	@Test
+	void actualTypeFromParameterNestedFlatWildcardTypeWithHintOverload() {
+		assertEquals(raw(Foo.class).parametized(String.class),
+				context.resolve("x", Que.class).genericFoo.actualType);
+	}
+
+	@Test
+	void actualTypeFromParameterDoubleNested() {
+		assertEquals(String.class, context.resolve(
+				Bar.class).superFoo.innerFoo.actualType.parameter(0).rawType);
+	}
+
+	@Test
+	void actualTypeFromParameterNestedTypeParameter() {
+		assertEquals(raw(Que.class),
+				context.resolve("x", Que.class).actualType);
+	}
+
+	/*
+	Name
+	 */
+
+	@Test
+	void actualNameFromAdHocInjected() {
+		assertEquals(named("ad-hoc"), context.resolve(named("ad-hoc"),
+				raw(Foo.class).parametized(String.class)).actualName);
+	}
+
+	@Test
+	void actualNameFromToClauseAndHintNested() {
+		Bar bar = context.resolve(Bar.class);
+		assertEquals(named("myNameNested"), bar.foo.actualName);
+		assertEquals(named("special"), bar.superFoo.actualName);
+	}
+
+	@Test
+	void actualNameFromToClauseDoubleNested() {
+		assertEquals(named("inner"),
+				context.resolve(Bar.class).superFoo.innerFoo.actualName);
+	}
+
+	@Test
+	void actualNameFromParameterNestedFlatWildcardType() {
+		assertEquals(Name.ANY,
+				context.resolve(Que.class).genericFoo.actualName);
+	}
+
+	@Test
+	void actualNameFromParameterNestedFlatWildcardTypeWithHintOverload() {
+		Que que = context.resolve("x", Que.class);
+		assertEquals(named("x"), que.actualName);
+		assertEquals(named("y"), que.genericFoo.actualName);
+	}
+
+	/*
+	Dependency
+	 */
+
+	@Test
+	void actualDependencyFromAdHoc() {
+		Type<Foo> type = raw(Foo.class).parametized(String.class);
+		assertSimilar(dependency(
+				type.asUpperBound().parametized(Type.WILDCARD)).injectingInto(
+				anyOf(raw(Foo.class))), context.resolve(type).actualDependency);
+	}
+
+	@Test
+	void actualDependencyFromParameterNestedFlatWildcardTypeWithHintOverload() {
+		Que que = context.resolve("x", Que.class);
+		assertSimilar(dependency(Que.class).injectingInto(
+				instance(named("x"), raw(Que.class))), que.actualDependency);
+	}
+
+	/**
+	 * There are lots of details in a {@link Dependency} - to replicate them all
+	 * exactly goes beyond what we try to check so we are happy if both have
+	 * the same string output.
+	 */
+	private void assertSimilar(Dependency<?> expected, Dependency<?> actual) {
+		assertEquals(expected.toString(), actual.toString());
+	}
+}

--- a/test.integration/test/java/test/integration/bind/TestFeatureTypeVariableTypeInjectionBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureTypeVariableTypeInjectionBinds.java
@@ -11,6 +11,7 @@ import se.jbee.inject.lang.Type;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static se.jbee.inject.config.ProducesBy.declaredMethods;
 import static se.jbee.inject.lang.Cast.functionTypeOf;
 
 /**
@@ -29,7 +30,7 @@ class TestFeatureTypeVariableTypeInjectionBinds {
 
 		@Override
 		protected void declare() {
-			autobind().produceBy(ProducesBy.declaredMethods).in(this);
+			autobind().produceBy(declaredMethods(false)).in(this);
 		}
 
 		/**

--- a/test.integration/test/java/test/integration/convert/TestConverter.java
+++ b/test.integration/test/java/test/integration/convert/TestConverter.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static se.jbee.inject.lang.Cast.listTypeOf;
 import static se.jbee.inject.Resource.resourceTypeOf;
+import static se.jbee.inject.lang.Cast.listTypeOf;
 import static se.jbee.inject.lang.Type.classType;
 import static se.jbee.inject.lang.Type.raw;
 import static se.jbee.inject.lang.Utils.arrayMap;

--- a/test.integration/test/java/test/integration/example/TestCustomAnnotationBinds.java
+++ b/test.integration/test/java/test/integration/example/TestCustomAnnotationBinds.java
@@ -1,11 +1,11 @@
 package test.integration.example;
 
-import test.example.app.Support;
 import org.junit.jupiter.api.Test;
 import se.jbee.inject.Injector;
 import se.jbee.inject.bind.ModuleWith;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
+import test.example.app.Support;
 
 import java.util.ServiceLoader;
 


### PR DESCRIPTION
- [x] Allow `Hint`s in `ProducesBy`
- [x] Allow `Hint`s in `ConstrucsBy`
- [x] Allow `Hint`s in `SharesBy` 
- [x] clarifies difference between `autobind()` and automatic _super_-class binds by renaming that to `superbind` 
- [x] replace auto-reading annotations in `annotatedWith` strategies
- [x] Adds `BindingConsolidation` as a new abstraction so that it can be customised
- [x] Adds _Self_ injection of `Type`, `Name` and `Dependency` (and in connection to that fixes number of generic issues with `Hint`s)