### PR TITLE
Localised Environment Properties

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,10 +2,14 @@
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="80" />
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
+    <JavaCodeStyleSettings>
+      <option name="JD_KEEP_INVALID_TAGS" value="false" />
+      <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+      <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
+      <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+    </JavaCodeStyleSettings>
     <codeStyleSettings language="JAVA">
-      <option name="KEEP_LINE_BREAKS" value="false" />
       <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
-      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
@@ -21,13 +25,17 @@
       <option name="THROWS_LIST_WRAP" value="1" />
       <option name="EXTENDS_KEYWORD_WRAP" value="1" />
       <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
       <option name="TERNARY_OPERATION_WRAP" value="5" />
       <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
       <option name="ARRAY_INITIALIZER_WRAP" value="1" />
       <option name="WRAP_COMMENTS" value="true" />
       <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
       <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
       <option name="ENUM_CONSTANTS_WRAP" value="5" />
+      <option name="SOFT_MARGINS" value="80" />
       <indentOptions>
         <option name="USE_TAB_CHARACTER" value="true" />
       </indentOptions>

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Env.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Env.java
@@ -21,17 +21,18 @@ import static se.jbee.inject.lang.Type.raw;
  * Type}s and the values instances of the key type.
  * <p>
  * To distinguish multiple values of the same {@link Type} a {@link Name}
- * qualifier is added.
+ * qualifier can be added added.
  * <p>
  * To avoid collisions between qualified properties as used within different
- * software modules that do not know about each other {@link Packages} are used
- * as namespaces.
+ * software modules properties are usually defined local to the defining
+ * software module. During lookup the {@link Class} of the processed module
+ * is used as the name-space key.
  * <p>
- * Properties that are considered namespace specific are resolved providing that
- * {@link Package} namespace based on the {@link Class} that uses the property.
+ * Properties that are considered namespace specific are resolved providing the
+ * {@link Class} of the defining module or "bean".
  * <p>
- * Properties that are considered "globally" used do not use a particular {@link
- * Package} as namespace which makes them "global".
+ * Properties that are considered "globally" used do not use a particular
+ * namespace ({@code null}).
  */
 @FunctionalInterface
 public interface Env {
@@ -41,22 +42,28 @@ public interface Env {
 	 * make private members accessible using
 	 * {@link java.lang.reflect.AccessibleObject#setAccessible(boolean)}
 	 */
-	String GP_USE_DEEP_REFLECTION = "deep-reflection";
+	String USE_DEEP_REFLECTION = "deep-reflection";
 
 	/**
 	 * Property name used to configure the set of {@link Packages} where deep
-	 * reflection is allowed given {@link #GP_USE_DEEP_REFLECTION} is true.
+	 * reflection is allowed given {@link #USE_DEEP_REFLECTION} is true.
 	 */
-	String GP_DEEP_REFLECTION_PACKAGES = "deep-reflection-packages";
+	String DEEP_REFLECTION_PACKAGES = "deep-reflection-packages";
 
 	/**
 	 * Property name used to configure a boolean if {@link Verifier}s are tried
 	 * to be resolved during the binding process. If not, {@link Verifier#AOK}
 	 * (no validation) is used (default).
 	 */
-	String GP_USE_VERIFICATION = "verify";
+	String USE_VERIFICATION = "verify";
 
-	String GP_BIND_BINDINGS = "self-bind";
+	/**
+	 * Boolean flag property which when set to {@code true} adds the bindings
+	 * that were the basis of an {@link Injector} or {@link Env} context as
+	 * a {@link Resource} in the context that can be resolved as array type of
+	 * the binding class used.
+	 */
+	String BIND_BINDINGS = "self-bind";
 
 	<T> T property(Name qualifier, Type<T> property, Class<?> ns)
 			throws InconsistentDeclaration;
@@ -101,8 +108,8 @@ public interface Env {
 	default Env in(Class<?> ns) {
 		final class EnvIn implements Env {
 
-			final Env env;
-			final Class<?> ns;
+			private final Env env;
+			private final Class<?> ns;
 
 			EnvIn(Env env, Class<?> ns) {
 				this.env = env;
@@ -125,6 +132,15 @@ public interface Env {
 			}
 		}
 		return ns == null ? this : new EnvIn(this, ns);
+	}
+
+	/**
+	 * @return An {@link Env} which isolates previous contributions using {@code
+	 * with} from future ones. In other words the set of added properties added
+	 * so far is not be changed by future {@code with} calls.
+	 */
+	default Env withIsolate() {
+		return this;
 	}
 
 	default Env with(String qualifier, boolean value) {
@@ -154,11 +170,13 @@ public interface Env {
 		 */
 		final class EnvWith implements Env {
 
-			final Env env;
-			final Map<Instance<?>, Object> values = new HashMap<>();
+			private final Env env;
+			private final Map<Instance<?>, Object> values;
+			private boolean isolate = false;
 
-			EnvWith(Env env) {
+			EnvWith(Env env, Map<Instance<?>, Object> values) {
 				this.env = env;
+				this.values = values;
 			}
 
 			@SuppressWarnings("unchecked")
@@ -172,17 +190,40 @@ public interface Env {
 			}
 
 			@Override
+			public Env withIsolate() {
+				isolate = true;
+				return this;
+			}
+
+			@Override
 			public <T> Env with(Name qualifier, Type<T> property, T value) {
+				if (isolate)
+					return new EnvWith(this, new HashMap<>()).with(qualifier, property, value);
 				values.put(instance(qualifier, property), value);
 				return this;
 			}
 
 			@Override
+			public Env in(Class<?> ns) {
+				Env in = env.in(ns);
+				return in == env ? this : new EnvWith(in, values);
+			}
+
+			@Override
 			public String toString() {
-				return "EnvWith{" + "env=" + env + ", values=" + values + '}';
+				StringBuilder str = new StringBuilder();
+				str.append("EnvWith[");
+				for (Map.Entry<Instance<?>, Object> e : values.entrySet()) {
+					str.append("\n  ").append(e.getKey().type.simpleName());
+					if (!e.getKey().name.isDefault())
+						str.append(" \"").append(e.getKey().name).append('"');
+					str.append(" = ").append(e.getValue());
+				}
+				str.append("\n]\n").append(env);
+				return str.toString();
 			}
 		}
-		return new EnvWith(this).with(qualifier, property, value);
+		return new EnvWith(this, new HashMap<>()).with(qualifier, property, value);
 	}
 
 	default <F extends Enum<F>> Env withToggled(Class<F> flags, F... enabled) {
@@ -202,8 +243,8 @@ public interface Env {
 	}
 
 	default <T extends  AccessibleObject & Member> void accessible(T target) {
-		if (property(Env.GP_USE_DEEP_REFLECTION, false)) {
-			Packages where = property(Env.GP_DEEP_REFLECTION_PACKAGES,
+		if (property(Env.USE_DEEP_REFLECTION, false)) {
+			Packages where = property(Env.DEEP_REFLECTION_PACKAGES,
 					Packages.class);
 			if (where.contains(target.getDeclaringClass()))
 				Reflect.accessible(target);
@@ -211,7 +252,7 @@ public interface Env {
 	}
 
 	default <T> Verifier verifierFor(T target) {
-		if (!property(Env.GP_USE_VERIFICATION, false))
+		if (!property(Env.USE_VERIFICATION, false))
 			return Verifier.AOK;
 		@SuppressWarnings("unchecked")
 		Class<T> targetClass = (Class<T>) target.getClass();

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Env.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Env.java
@@ -226,20 +226,21 @@ public interface Env {
 		return new EnvWith(this, new HashMap<>()).with(qualifier, property, value);
 	}
 
-	default <F extends Enum<F>> Env withToggled(Class<F> flags, F... enabled) {
+	@SuppressWarnings("unchecked")
+	default <E extends Enum<E>> Env withDependent(Class<E> set, E... elements) {
 		Env res = this;
-		for (F flag : enabled) {
-			res = flag == null
-					? res.with("null", flags, null)
-					: res.with(flag.name(), raw(flags), flag);
+		for (E e : elements) {
+			res = e == null
+					? res.with("null", set, null)
+					: res.with(e.name(), raw(set), e);
 		}
 		return res;
 	}
 
-	default <E extends Enum<E>> boolean toggled(Class<E> property, E feature) {
-		return feature == null
-				? property("null", property, property.getEnumConstants()[0]) == null
-				: property(feature.name(), property,null) != null;
+	default <E extends Enum<E>> boolean isInstalled(Class<E> dependentOn, E element) {
+		return element == null
+				? property("null", dependentOn, dependentOn.getEnumConstants()[0]) == null
+				: property(element.name(), dependentOn,null) != null;
 	}
 
 	default <T extends  AccessibleObject & Member> void accessible(T target) {

--- a/se.jbee.inject.api/main/java/se/jbee/inject/Extends.java
+++ b/se.jbee.inject.api/main/java/se/jbee/inject/Extends.java
@@ -50,11 +50,4 @@ public @interface Extends {
 	 */
 	Class<?> value();
 
-	/**
-	 * @return if true the declarations made in the annotated module are limited
-	 * to the package the declaring class is defined in (including is
-	 * sub-packages). Not that this only has an effect on the directly annotated
-	 * class. It is not propagated to bundles installed by it.
-	 */
-	boolean local() default false;
 }

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Dependent.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/Dependent.java
@@ -6,22 +6,20 @@
 package se.jbee.inject.bind;
 
 import se.jbee.inject.Env;
-import se.jbee.inject.bind.Bootstrapper.ToggledBootstrapper;
+import se.jbee.inject.bind.Bootstrapper.DependentBootstrapper;
 
 /**
  * A {@link Bundle} that does installs {@link Bundle}s in connected to a feature
  * flag represented by an {@link Enum} constant. If the flag is
- * {@link Env#toggled(Class, Enum)} the {@link Bundle} is installed,
+ * {@link Env#isInstalled(Class, Enum)} the {@link Bundle} is installed,
  * otherwise it isn't.
- *
- * @author Jan Bernitt (jan@jbee.se)
  */
 @FunctionalInterface
-public interface Toggled<F> {
+public interface Dependent<F> {
 
 	/**
-	 * @param bootstrapper the {@link ToggledBootstrapper} this bundle should
+	 * @param bootstrapper the {@link DependentBootstrapper} this bundle should
 	 *            install itself in.
 	 */
-	void bootstrap(ToggledBootstrapper<F> bootstrapper);
+	void bootstrap(DependentBootstrapper<F> bootstrapper);
 }

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/bind/package-info.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/bind/package-info.java
@@ -26,10 +26,10 @@
  *
  * <h2>Feature Switches</h2>
  * <p>
- * {@link se.jbee.inject.bind.Toggled} {@link java.lang.Enum}s can be used to
+ * {@link se.jbee.inject.bind.Dependent} {@link java.lang.Enum}s can be used to
  * implement feature toggles where a {@link se.jbee.inject.bind.Bundle} is only
  * installed if the {@link java.lang.Enum} constant associated with the {@link
- * se.jbee.inject.bind.Bundle} is {@link se.jbee.inject.Env#toggled(java.lang.Class,
+ * se.jbee.inject.bind.Bundle} is {@link se.jbee.inject.Env#isInstalled(java.lang.Class,
  * java.lang.Enum)}. Besides being useful as feature switch this also allows to
  * hide actual {@link se.jbee.inject.bind.Bundle} implementation classes and
  * make them accessible through a {@link java.lang.Enum} and its constants. This

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Binder.java
@@ -793,12 +793,12 @@ public class Binder {
 			Name name = namesBy.reflect(target);
 			Class<T> impl = target.getDeclaringClass();
 			Binder scopedBinder = binder.per(scope != null ? scope : Scope.auto).implicit();
+			scopedBinder.bind(name, impl).to(target, hints);
 			if (name.isDefault()) {
 				scopedBinder.contractbind(impl)
 						//TODO use actual type hint/ref
 						.expand(constructs(raw(impl), target, hintsBy, hints));
 			} else {
-				scopedBinder.bind(name, impl).to(target, hints);
 				for (Type<? super T> st : raw(impl).supertypes())
 					if (st.isInterface())
 						scopedBinder.implicit().bind(name, st).to(name, impl);

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModuleWith.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModuleWith.java
@@ -37,7 +37,7 @@ public abstract class BinderModuleWith<T> extends InitializedBinder
 
 	@Override
 	public void declare(Bindings bindings, Env env, T property) {
-		__init__(configure(env), bindings);
+		__init__(configure(env.withIsolate()), bindings);
 		declare(property);
 	}
 

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModuleWith.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BinderModuleWith.java
@@ -22,8 +22,6 @@ import static se.jbee.inject.lang.Type.raw;
  * A {@link BinderModuleWith} is also a {@link Bundle} so it should be used and
  * installed as such. It will than {@link Bundle#bootstrap(Bootstrapper)} itself
  * as a module.
- *
- * @author Jan Bernitt (jan@jbee.se)
  */
 public abstract class BinderModuleWith<T> extends InitializedBinder
 		implements Bundle, ModuleWith<T> {

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BootstrapperBundle.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BootstrapperBundle.java
@@ -45,28 +45,28 @@ public abstract class BootstrapperBundle implements Bundle, Bootstrapper {
 
 	@Override
 	@SafeVarargs
-	public final <M extends Enum<M> & Toggled<M>> void install(M... modules) {
-		bootstrap.install(modules);
+	public final <M extends Enum<M> & Dependent<M>> void install(M... elements) {
+		bootstrap.install(elements);
 	}
 
 	@Override
 	public final <C extends Enum<C>> void install(
-			Class<? extends Toggled<C>> bundle, Class<C> property) {
-		bootstrap.install(bundle, property);
+			Class<? extends Dependent<C>> bundle, Class<C> dependentOn) {
+		bootstrap.install(bundle, dependentOn);
 	}
 
 	@Override
 	@SafeVarargs
-	public final <O extends Enum<O> & Toggled<O>> void uninstall(O... flags) {
-		bootstrap.uninstall(flags);
+	public final <O extends Enum<O> & Dependent<O>> void uninstall(O... elements) {
+		bootstrap.uninstall(elements);
 	}
 
-	protected final <O extends Enum<O> & Toggled<O>> void installAll(
+	protected final <O extends Enum<O> & Dependent<O>> void installAll(
 			Class<O> optionsOfType) {
 		install(optionsOfType.getEnumConstants());
 	}
 
-	protected final <O extends Enum<O> & Toggled<O>> void uninstallAll(
+	protected final <O extends Enum<O> & Dependent<O>> void uninstallAll(
 			Class<O> optionsOfType) {
 		uninstall(optionsOfType.getEnumConstants());
 	}

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BundleFor.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/BundleFor.java
@@ -6,45 +6,45 @@
 package se.jbee.inject.binder;
 
 import se.jbee.inject.bind.Bootstrapper;
-import se.jbee.inject.bind.Bootstrapper.ToggledBootstrapper;
+import se.jbee.inject.bind.Bootstrapper.DependentBootstrapper;
 import se.jbee.inject.bind.Bundle;
+import se.jbee.inject.bind.Dependent;
 import se.jbee.inject.bind.InconsistentBinding;
-import se.jbee.inject.bind.Toggled;
 import se.jbee.inject.lang.Type;
 
 import static se.jbee.inject.lang.Type.raw;
 
 /**
- * The default utility base class for {@link Toggled}s.
+ * The default utility base class for {@link Dependent}s.
  *
- * @param <C> the type of the options values (usually an enum)
+ * @param <E> the type of the options values (usually an enum)
  */
-public abstract class BundleFor<C> implements Toggled<C>,
-		ToggledBootstrapper<C> {
+public abstract class BundleFor<E> implements Dependent<E>,
+		Bootstrapper.DependentBootstrapper<E> {
 
-	private Bootstrapper.ToggledBootstrapper<C> bootstrapper;
+	private DependentBootstrapper<E> bootstrapper;
 
 	@Override
-	public void bootstrap(Bootstrapper.ToggledBootstrapper<C> bs) {
+	public void bootstrap(Bootstrapper.DependentBootstrapper<E> bs) {
 		InconsistentBinding.nonnullThrowsReentranceException(bootstrapper);
 		this.bootstrapper = bs;
 		bootstrap();
 	}
 
 	@Override
-	public final void install(Class<? extends Bundle> bundle, C flag) {
-		bootstrapper.install(bundle, flag);
+	public final void installDependentOn(E element, Class<? extends Bundle> bundle) {
+		bootstrapper.installDependentOn(element, bundle);
 	}
 
 	@Override
 	public final String toString() {
-		Type<?> module = raw(getClass()).toSuperType(Toggled.class).parameter(0);
+		Type<?> module = raw(getClass()).toSuperType(Dependent.class).parameter(0);
 		return "bundle " + getClass().getSimpleName() + "[" + module + "]";
 	}
 
 	/**
-	 * Use {@link #install(Class, Object)} for option dependent {@link Bundle}
-	 * installation.
+	 * Use {@link DependentBootstrapper#installDependentOn(Object, Class)} for
+	 * option dependent {@link Bundle} installation.
 	 */
 	protected abstract void bootstrap();
 }

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/EnvModule.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/EnvModule.java
@@ -14,6 +14,11 @@ import se.jbee.inject.config.ContractsBy;
 public abstract class EnvModule extends BinderModule {
 
 	@Override
+	protected final boolean installDefaults() {
+		return false;
+	}
+
+	@Override
 	protected Bind init(Bind bind) {
 		return bind.per(Scope.container);
 	}
@@ -30,8 +35,4 @@ public abstract class EnvModule extends BinderModule {
 		return bind(Name.named(type), ContractsBy.class);
 	}
 
-	@Override
-	protected final boolean installDefaults() {
-		return false;
-	}
 }

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/InitializedBinder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/InitializedBinder.java
@@ -6,7 +6,6 @@
 package se.jbee.inject.binder;
 
 import se.jbee.inject.Env;
-import se.jbee.inject.Extends;
 import se.jbee.inject.InconsistentDeclaration;
 import se.jbee.inject.bind.*;
 import se.jbee.inject.binder.Binder.RootBinder;
@@ -55,7 +54,7 @@ public abstract class InitializedBinder extends RootBinder {
 			}
 			if (installs.features() != Enum.class) {
 				Class<?> features = installs.features();
-				if (!raw(features).isAssignableTo(raw(Toggled.class)))
+				if (!raw(features).isAssignableTo(raw(Dependent.class)))
 					throw new InconsistentDeclaration(
 							"@Installs feature Class must be compatible with <F extends Enum<F> & Toggled<F>>");
 				install(bootstrap, (Class) features, installs.selection());
@@ -63,7 +62,7 @@ public abstract class InitializedBinder extends RootBinder {
 		}
 	}
 
-	private <F extends Enum<F> & Toggled<F>> void install(
+	private <F extends Enum<F> & Dependent<F>> void install(
 			Bootstrapper bootstrap, Class<F> features, String[] names) {
 		if (names.length == 0) {
 			bootstrap.install(features.getEnumConstants());

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/InitializedBinder.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/InitializedBinder.java
@@ -37,13 +37,7 @@ public abstract class InitializedBinder extends RootBinder {
 
 	protected final void __init__(Env env, Bindings bindings) {
 		InconsistentBinding.nonnullThrowsReentranceException(initialized);
-		Bind into = bind.into(env, bindings);
-		if (getClass().isAnnotationPresent(Extends.class)) {
-			Extends e = getClass().getAnnotation(Extends.class);
-			if (e.local())
-				into = into.with((into.target.inPackageAndSubPackagesOf(getClass())));
-		}
-		this.bind = init(into);
+		this.bind = init(bind.into(env, bindings));
 		initialized = true;
 	}
 

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Installs.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/Installs.java
@@ -1,6 +1,7 @@
 package se.jbee.inject.binder;
 
 import se.jbee.inject.bind.Bundle;
+import se.jbee.inject.bind.Dependent;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
@@ -15,7 +16,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * Its main purpose is to be used when writing a {@link BinderModule} or {@link
  * BinderModuleWith} which depends upon other {@link Bundle}s or {@link
- * se.jbee.inject.bind.Toggled} bundles being installed. In such a case the
+ * Dependent} bundles being installed. In such a case the
  * {@link BinderModule} or {@link BinderModuleWith} can be annotated instead
  * referencing to its "dependencies" which avoid needing to create a bundle that
  * installs the module and the dependencies.
@@ -43,14 +44,14 @@ public @interface Installs {
 	Class<? extends Bundle>[] bundles() default {};
 
 	/**
-	 * @return Must be a {@link se.jbee.inject.bind.Toggled} {@link Enum} type.
+	 * @return Must be a {@link Dependent} {@link Enum} type.
 	 * If {@link #selection()} is empty all its features are installed.
 	 * Otherwise only the features named in {@link #selection()} are installed.
 	 */
 	Class<? extends Enum> features() default Enum.class;
 
 	/**
-	 * @return When {@link #features()} refers to a {@link se.jbee.inject.bind.Toggled}
+	 * @return When {@link #features()} refers to a {@link Dependent}
 	 * {@link Enum} type the selection contains the enum constant names of the
 	 * features that should be installed. If all should be installed this can be
 	 * empty (default value).

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/binder/LocalEnvModule.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/binder/LocalEnvModule.java
@@ -1,0 +1,12 @@
+package se.jbee.inject.binder;
+
+import se.jbee.inject.bind.Bind;
+
+public abstract class LocalEnvModule extends EnvModule {
+
+	@Override
+	protected Bind init(Bind bind) {
+		Bind res = super.init(bind);
+		return res.with(res.target.inPackageAndSubPackagesOf(getClass()));
+	}
+}

--- a/se.jbee.inject.bind/main/java/se/jbee/inject/config/Config.java
+++ b/se.jbee.inject.bind/main/java/se/jbee/inject/config/Config.java
@@ -90,6 +90,12 @@ public class Config implements ContextAware<Config>, Extension {
 					.map(converter::convert);
 		}
 
+		public Source source() {
+			Dependency<A> dep = toDependency(from, property);
+			Resource<?> r = context.resolve(dep.typed(Resource.resourceTypeOf(dep.type())));
+			return r.source;
+		}
+
 		public <B> B as(Class<B> type, B defaultValue) {
 			return as(type).orElse(defaultValue);
 		}

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/InjectorFeature.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/bootstrap/InjectorFeature.java
@@ -5,7 +5,7 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.bind.Bindings;
 import se.jbee.inject.bind.Bootstrapper;
 import se.jbee.inject.bind.Bundle;
-import se.jbee.inject.bind.Toggled;
+import se.jbee.inject.bind.Dependent;
 import se.jbee.inject.binder.BinderModule;
 
 import java.util.function.Function;
@@ -18,7 +18,7 @@ import static se.jbee.inject.lang.Cast.functionTypeOf;
  * By default the {@link Bootstrap} utility will install all features.
  * Use {@link Bootstrapper#uninstall(Enum[])} to remove any unwanted capability.
  */
-public enum InjectorFeature implements Toggled<InjectorFeature> {
+public enum InjectorFeature implements Dependent<InjectorFeature> {
 	/**
 	 * Binds a {@link Function} that given an array of {@link Class} (that must
 	 * extend {@link Bundle}) creates or returns an {@link Injector} sub-context
@@ -30,8 +30,9 @@ public enum InjectorFeature implements Toggled<InjectorFeature> {
 
 	@Override
 	public void bootstrap(
-			Bootstrapper.ToggledBootstrapper<InjectorFeature> bootstrapper) {
-		bootstrapper.install(SubContextFunction.class, SUB_CONTEXT_FUNCTION);
+			Bootstrapper.DependentBootstrapper<InjectorFeature> bootstrapper) {
+		bootstrapper.installDependentOn(SUB_CONTEXT_FUNCTION,
+				SubContextFunction.class);
 	}
 
 	static final class SubContextFunction extends BinderModule {

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultBindingConsolidation.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultBindingConsolidation.java
@@ -91,7 +91,7 @@ public final class DefaultBindingConsolidation {
 		}
 		if (!required.isEmpty())
 			throw new ResourceResolutionFailed(required, dropped);
-		return env.property(Env.GP_BIND_BINDINGS, false)
+		return env.property(Env.BIND_BINDINGS, false)
 			   ? withListItselfInserted(res)
 			   : arrayOf(res, Binding.class);
 	}

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultEnv.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultEnv.java
@@ -11,6 +11,10 @@ import se.jbee.inject.lang.Type;
 
 import static se.jbee.inject.lang.Type.raw;
 
+/**
+ * The {@link se.jbee.inject.bind.Module} that setups the values required in an
+ * {@link Env} used with the {@link Binder} API.
+ */
 public class DefaultEnv extends ConstantsModule {
 
 	public static Env bootstrap() {

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultEnv.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultEnv.java
@@ -57,13 +57,14 @@ public class DefaultEnv extends ConstantsModule {
 		bind(BindingConsolidation.class).to(DefaultBindingConsolidation::consolidate);
 
 		// do not use deep reflection (set accessible) (but if enabled use it everywhere)
-		bind(Env.GP_USE_DEEP_REFLECTION, boolean.class).to(false);
-		bind(Env.GP_DEEP_REFLECTION_PACKAGES, Packages.class).to(Packages.ALL);
+		bind(Env.USE_DEEP_REFLECTION, boolean.class).to(false);
+		bind(Env.DEEP_REFLECTION_PACKAGES, Packages.class).to(Packages.ALL);
 
 		// verification is off
-		bind(Env.GP_USE_VERIFICATION, boolean.class).to(false);
+		bind(Env.USE_VERIFICATION, boolean.class).to(false);
 
 		// extras
 		bind(Plugins.class).toFactory(Plugins::new);
+		bind(Annotated.Enhancer.class).to(Annotated.SOURCE);
 	}
 }

--- a/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultFeature.java
+++ b/se.jbee.inject.bootstrap/main/java/se/jbee/inject/defaults/DefaultFeature.java
@@ -8,7 +8,7 @@ package se.jbee.inject.defaults;
 import se.jbee.inject.*;
 import se.jbee.inject.bind.Bootstrapper;
 import se.jbee.inject.bind.Bundle;
-import se.jbee.inject.bind.Toggled;
+import se.jbee.inject.bind.Dependent;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.Supply;
 import se.jbee.inject.config.Extension;
@@ -30,7 +30,7 @@ import static se.jbee.inject.lang.Type.raw;
 /**
  * Installs all the build-in functionality by using the core API.
  */
-public enum DefaultFeature implements Toggled<DefaultFeature> {
+public enum DefaultFeature implements Dependent<DefaultFeature> {
 	/**
 	 * Adds: {@link Provider}s can be injected for all bound types.
 	 */
@@ -106,21 +106,21 @@ public enum DefaultFeature implements Toggled<DefaultFeature> {
 
 	@Override
 	public void bootstrap(
-			Bootstrapper.ToggledBootstrapper<DefaultFeature> bootstrapper) {
-		bootstrapper.install(ListBridgeModule.class, LIST);
-		bootstrapper.install(SetBridgeModule.class, SET);
-		bootstrapper.install(CollectionBridgeModule.class, COLLECTION);
-		bootstrapper.install(ProviderBridgeModule.class, PROVIDER);
-		bootstrapper.install(LoggerModule.class, LOGGER);
-		bootstrapper.install(OptionalBridgeModule.class, OPTIONAL);
-		bootstrapper.install(SubContextModule.class, SUB_CONTEXT);
-		bootstrapper.install(DefaultEnvModule.class, ENV);
-		bootstrapper.install(DefaultScopes.class, SCOPES);
-		bootstrapper.install(ExtensionModule.class, EXTENSION);
-		bootstrapper.install(PrimitiveArraysModule.class, PRIMITIVE_ARRAYS);
-		bootstrapper.install(AnnotatedWithModule.class, ANNOTATED_WITH);
-		bootstrapper.install(ObtainableModule.class, OBTAINABLE);
-		bootstrapper.install(SelfModule.class, SELF);
+			Bootstrapper.DependentBootstrapper<DefaultFeature> bootstrapper) {
+		bootstrapper.installDependentOn(LIST, ListBridgeModule.class);
+		bootstrapper.installDependentOn(SET, SetBridgeModule.class);
+		bootstrapper.installDependentOn(COLLECTION, CollectionBridgeModule.class);
+		bootstrapper.installDependentOn(PROVIDER, ProviderBridgeModule.class);
+		bootstrapper.installDependentOn(LOGGER, LoggerModule.class);
+		bootstrapper.installDependentOn(OPTIONAL, OptionalBridgeModule.class);
+		bootstrapper.installDependentOn(SUB_CONTEXT, SubContextModule.class);
+		bootstrapper.installDependentOn(ENV, DefaultEnvModule.class);
+		bootstrapper.installDependentOn(SCOPES, DefaultScopes.class);
+		bootstrapper.installDependentOn(EXTENSION, ExtensionModule.class);
+		bootstrapper.installDependentOn(PRIMITIVE_ARRAYS, PrimitiveArraysModule.class);
+		bootstrapper.installDependentOn(ANNOTATED_WITH, AnnotatedWithModule.class);
+		bootstrapper.installDependentOn(OBTAINABLE, ObtainableModule.class);
+		bootstrapper.installDependentOn(SELF, SelfModule.class);
 	}
 
 	private static class LoggerModule extends BinderModule {

--- a/se.jbee.inject.container/main/java/se/jbee/inject/container/Resources.java
+++ b/se.jbee.inject.container/main/java/se/jbee/inject/container/Resources.java
@@ -77,15 +77,18 @@ final class Resources {
 
 	private static void toString(StringBuilder b, String group,
 			Resource<?>[] rs) {
-		b.append(group).append('\n');
+		b.append("  ").append(group).append('\n');
 		for (Resource<?> rx : rs) {
 			Locator<?> r = rx.signature;
-			b.append("\t#").append(rx.serialID).append(' ');
-			b.append(r.type().simpleName()).append(' ');
-			b.append(r.instance.name).append(' ');
-			b.append(r.target).append(' ');
-			b.append(rx.lifeCycle).append(' ');
-			b.append(rx.source).append('\n');
+			b.append("\t#").append(rx.serialID).append("\t ");
+			String id = r.type().simpleName();
+			if (!r.instance.name.isDefault())
+				id += " \"" + r.instance.name+"\"";
+			b.append(String.format("%-40s ", id));
+			if (!r.target.isAny())
+				b.append(r.target).append(' ');
+			b.append("⏳ ").append(rx.lifeCycle).append(' ');
+			b.append("⚡ ").append(rx.source).append('\n');
 		}
 	}
 

--- a/test.examples/test/java/module-info.java
+++ b/test.examples/test/java/module-info.java
@@ -1,18 +1,21 @@
-import test.example1.MyEnvSetupBundle;
-import test.example1.MyRootBundle;
+import test.ExamplesBundle;
+import test.ExamplesEnvBundle;
 import test.example1.SupportAnnotationPattern;
 
 /**
  * Contains an example application used in tests to test the {@link
  * java.util.ServiceLoader} based features.
  */
-@SuppressWarnings("Java9RedundantRequiresStatement") module test.examples {
+@SuppressWarnings("Java9RedundantRequiresStatement")
+open module test.examples {
 
+  exports test;
   exports test.example1;
+  exports test.example2;
 
   requires transitive se.jbee.inject;
 
-  provides se.jbee.inject.bind.Bundle with MyRootBundle, MyEnvSetupBundle;
+  provides se.jbee.inject.bind.Bundle with ExamplesBundle, ExamplesEnvBundle;
 
   provides se.jbee.inject.bind.ModuleWith with SupportAnnotationPattern;
 }

--- a/test.examples/test/java/test/Example.java
+++ b/test.examples/test/java/test/Example.java
@@ -1,0 +1,20 @@
+package test;
+
+import se.jbee.inject.Env;
+import se.jbee.inject.Injector;
+import se.jbee.inject.bootstrap.Bootstrap;
+
+public enum Example {
+
+	EXAMPLE_1,
+	EXAMPLE_2;
+
+	public Env env() {
+		return Bootstrap.env(
+				Bootstrap.DEFAULT_ENV.withDependent(Example.class, this));
+	}
+
+	public Injector injector() {
+		return Bootstrap.injector(env().withDependent(Example.class, this));
+	}
+}

--- a/test.examples/test/java/test/ExamplesBundle.java
+++ b/test.examples/test/java/test/ExamplesBundle.java
@@ -1,0 +1,20 @@
+package test;
+
+import se.jbee.inject.bind.Bootstrapper;
+import se.jbee.inject.bind.Bundle;
+import se.jbee.inject.binder.BundleFor;
+import test.example1.Example1RootBundle;
+import test.example2.Example2Bundle;
+
+public class ExamplesBundle extends BundleFor<Example> implements Bundle {
+	@Override
+	protected void bootstrap() {
+		installDependentOn(Example.EXAMPLE_1, Example1RootBundle.class);
+		installDependentOn(Example.EXAMPLE_2, Example2Bundle.class);
+	}
+
+	@Override
+	public void bootstrap(Bootstrapper bootstrap) {
+		bootstrap.install(getClass(), Example.class);
+	}
+}

--- a/test.examples/test/java/test/ExamplesEnvBundle.java
+++ b/test.examples/test/java/test/ExamplesEnvBundle.java
@@ -1,0 +1,24 @@
+package test;
+
+import se.jbee.inject.Env;
+import se.jbee.inject.Extends;
+import se.jbee.inject.bind.Bootstrapper;
+import se.jbee.inject.bind.Bundle;
+import se.jbee.inject.binder.BundleFor;
+import test.example1.Example1EnvBundle;
+import test.example2.Example2EnvBundle;
+
+@Extends(Env.class)
+public class ExamplesEnvBundle extends BundleFor<Example> implements Bundle {
+
+	@Override
+	protected void bootstrap() {
+		installDependentOn(Example.EXAMPLE_1, Example1EnvBundle.class);
+		installDependentOn(Example.EXAMPLE_2, Example2EnvBundle.class);
+	}
+
+	@Override
+	public void bootstrap(Bootstrapper bootstrap) {
+		bootstrap.install(getClass(), Example.class);
+	}
+}

--- a/test.examples/test/java/test/example1/Example1EnvBundle.java
+++ b/test.examples/test/java/test/example1/Example1EnvBundle.java
@@ -1,11 +1,8 @@
 package test.example1;
 
-import se.jbee.inject.Env;
-import se.jbee.inject.Extends;
 import se.jbee.inject.binder.EnvModule;
 
-@Extends(Env.class)
-public class MyEnvSetupBundle extends EnvModule {
+public class Example1EnvBundle extends EnvModule {
 
 	@Override
 	protected void declare() {

--- a/test.examples/test/java/test/example1/Example1Module.java
+++ b/test.examples/test/java/test/example1/Example1Module.java
@@ -2,7 +2,7 @@ package test.example1;
 
 import se.jbee.inject.binder.BinderModuleWith;
 
-public class MyFirstModule extends BinderModuleWith<Integer> {
+public class Example1Module extends BinderModuleWith<Integer> {
 
 	@Override
 	protected void declare(Integer value) {

--- a/test.examples/test/java/test/example1/Example1RootBundle.java
+++ b/test.examples/test/java/test/example1/Example1RootBundle.java
@@ -2,11 +2,11 @@ package test.example1;
 
 import se.jbee.inject.binder.BootstrapperBundle;
 
-public class MyRootBundle extends BootstrapperBundle {
+public class Example1RootBundle extends BootstrapperBundle {
 
 	@Override
 	protected void bootstrap() {
-		install(MyFirstModule.class);
+		install(Example1Module.class);
 	}
 
 }

--- a/test.examples/test/java/test/example2/Bus.java
+++ b/test.examples/test/java/test/example2/Bus.java
@@ -1,0 +1,10 @@
+package test.example2;
+
+public class Bus {
+
+	public final String to;
+
+	public Bus(String to) {
+		this.to = to;
+	}
+}

--- a/test.examples/test/java/test/example2/Car.java
+++ b/test.examples/test/java/test/example2/Car.java
@@ -1,0 +1,10 @@
+package test.example2;
+
+public class Car {
+
+	public final String owner;
+
+	public Car(String owner) {
+		this.owner = owner;
+	}
+}

--- a/test.examples/test/java/test/example2/Example2Bundle.java
+++ b/test.examples/test/java/test/example2/Example2Bundle.java
@@ -1,0 +1,14 @@
+package test.example2;
+
+import se.jbee.inject.binder.BootstrapperBundle;
+import test.example2.bus.BusModule;
+import test.example2.car.CarModule;
+
+public class Example2Bundle extends BootstrapperBundle  {
+
+	@Override
+	protected void bootstrap() {
+		install(CarModule.class);
+		install(BusModule.class);
+	}
+}

--- a/test.examples/test/java/test/example2/Example2EnvBundle.java
+++ b/test.examples/test/java/test/example2/Example2EnvBundle.java
@@ -1,0 +1,17 @@
+package test.example2;
+
+import se.jbee.inject.Env;
+import se.jbee.inject.Extends;
+import se.jbee.inject.binder.BootstrapperBundle;
+import test.example2.bus.BusEnvModule;
+import test.example2.car.CarEnvModule;
+
+@Extends(Env.class)
+public class Example2EnvBundle extends BootstrapperBundle {
+
+	@Override
+	protected void bootstrap() {
+		install(CarEnvModule.class);
+		install(BusEnvModule.class);
+	}
+}

--- a/test.examples/test/java/test/example2/bus/BusEnvModule.java
+++ b/test.examples/test/java/test/example2/bus/BusEnvModule.java
@@ -1,0 +1,18 @@
+package test.example2.bus;
+
+import se.jbee.inject.binder.LocalEnvModule;
+import se.jbee.inject.config.NamesBy;
+import se.jbee.inject.config.ProducesBy;
+import test.example2.Bus;
+
+import static se.jbee.inject.lang.Type.raw;
+
+public class BusEnvModule extends LocalEnvModule {
+
+	@Override
+	protected void declare() {
+		bind(NamesBy.class).to(NamesBy.DECLARED_NAME);
+		bind(ProducesBy.class).to(ProducesBy.declaredMethods(false)
+				.returnTypeAssignableTo(raw(Bus.class)));
+	}
+}

--- a/test.examples/test/java/test/example2/bus/BusModule.java
+++ b/test.examples/test/java/test/example2/bus/BusModule.java
@@ -1,0 +1,10 @@
+package test.example2.bus;
+
+import se.jbee.inject.binder.BinderModule;
+
+public class BusModule extends BinderModule {
+	@Override
+	protected void declare() {
+		autobind().in(BusService.class);
+	}
+}

--- a/test.examples/test/java/test/example2/bus/BusService.java
+++ b/test.examples/test/java/test/example2/bus/BusService.java
@@ -1,0 +1,22 @@
+package test.example2.bus;
+
+import test.example2.Bus;
+import test.example2.Car;
+
+public class BusService {
+
+	public Bus toLondon() {
+		return new Bus("London");
+	}
+
+	public Bus toGlasgow() {
+		return new Bus("Glasgow");
+	}
+
+	/**
+	 * This should not be picked as it does not return a {@link Bus}
+	 */
+	public Car carOfBusDriver() {
+		return new Car("bus-driver-to-London");
+	}
+}

--- a/test.examples/test/java/test/example2/car/CarEnvModule.java
+++ b/test.examples/test/java/test/example2/car/CarEnvModule.java
@@ -1,0 +1,20 @@
+package test.example2.car;
+
+import se.jbee.inject.binder.Installs;
+import se.jbee.inject.binder.LocalEnvModule;
+import se.jbee.inject.config.NamesBy;
+import se.jbee.inject.config.ProducesBy;
+import se.jbee.inject.lang.Type;
+import test.example2.Car;
+import test.example2.car.pool.CarPoolEnvModule;
+
+@Installs(bundles = CarPoolEnvModule.class)
+public class CarEnvModule extends LocalEnvModule {
+
+	@Override
+	protected void declare() {
+		bind(NamesBy.class).to(NamesBy.DECLARED_NAME);
+		bind(ProducesBy.class).to(ProducesBy.declaredMethods(false)
+			.returnTypeAssignableTo(Type.raw(Car.class)));
+	}
+}

--- a/test.examples/test/java/test/example2/car/CarModule.java
+++ b/test.examples/test/java/test/example2/car/CarModule.java
@@ -1,0 +1,15 @@
+package test.example2.car;
+
+import se.jbee.inject.binder.BinderModule;
+import se.jbee.inject.binder.Installs;
+import test.example2.car.pool.CarPoolModule;
+
+@Installs(bundles = CarPoolModule.class)
+public class CarModule extends BinderModule {
+
+	@Override
+	protected void declare() {
+		autobind().in(CarService.class);
+	}
+
+}

--- a/test.examples/test/java/test/example2/car/CarService.java
+++ b/test.examples/test/java/test/example2/car/CarService.java
@@ -1,0 +1,20 @@
+package test.example2.car;
+
+import test.example2.Bus;
+import test.example2.Car;
+
+public class CarService {
+
+	public Car getPetersCar() {
+		return new Car("Peter");
+	}
+
+	public Car getPaulsCar() {
+		return new Car("Paul");
+	}
+
+	public Bus busStopAtCarPark() {
+		return new Bus("at-car-park");
+	}
+
+}

--- a/test.examples/test/java/test/example2/car/pool/CarPoolEnvModule.java
+++ b/test.examples/test/java/test/example2/car/pool/CarPoolEnvModule.java
@@ -1,0 +1,15 @@
+package test.example2.car.pool;
+
+import se.jbee.inject.binder.LocalEnvModule;
+import se.jbee.inject.config.ProducesBy;
+import test.example2.Car;
+
+import static se.jbee.inject.lang.Type.raw;
+
+public class CarPoolEnvModule extends LocalEnvModule  {
+	@Override
+	protected void declare() {
+		bind(ProducesBy.class).to(ProducesBy.declaredMethods(false)
+				.returnTypeAssignableTo(raw(Car[].class)));
+	}
+}

--- a/test.examples/test/java/test/example2/car/pool/CarPoolModule.java
+++ b/test.examples/test/java/test/example2/car/pool/CarPoolModule.java
@@ -1,0 +1,14 @@
+package test.example2.car.pool;
+
+import se.jbee.inject.binder.BinderModule;
+import se.jbee.inject.binder.Installs;
+import test.example2.car.pool.corporate.CorporateCarPoolModule;
+
+@Installs(bundles = CorporateCarPoolModule.class)
+public class CarPoolModule extends BinderModule {
+
+	@Override
+	protected void declare() {
+		autobind().in(CarPoolService.class);
+	}
+}

--- a/test.examples/test/java/test/example2/car/pool/CarPoolService.java
+++ b/test.examples/test/java/test/example2/car/pool/CarPoolService.java
@@ -1,0 +1,19 @@
+package test.example2.car.pool;
+
+import test.example2.Bus;
+import test.example2.Car;
+
+public class CarPoolService {
+
+	public Car[] poolCars() {
+		return new Car[] { new Car("pool1"), new Car("pool2") };
+	}
+
+	public Car nextPoolCar() {
+		return null;
+	}
+
+	public Bus stopAtCarPool() {
+		return new Bus("stop-at-car-pool");
+	}
+}

--- a/test.examples/test/java/test/example2/car/pool/corporate/CorporateCarPoolModule.java
+++ b/test.examples/test/java/test/example2/car/pool/corporate/CorporateCarPoolModule.java
@@ -1,0 +1,11 @@
+package test.example2.car.pool.corporate;
+
+import se.jbee.inject.binder.BinderModule;
+
+public class CorporateCarPoolModule extends BinderModule {
+
+	@Override
+	protected void declare() {
+		autobind().in(CorporateCarPoolService.class);
+	}
+}

--- a/test.examples/test/java/test/example2/car/pool/corporate/CorporateCarPoolService.java
+++ b/test.examples/test/java/test/example2/car/pool/corporate/CorporateCarPoolService.java
@@ -1,0 +1,10 @@
+package test.example2.car.pool.corporate;
+
+import test.example2.Car;
+
+public class CorporateCarPoolService {
+
+	public Car[] corporatePool() {
+		return new Car[] { new Car("monopoly1") };
+	}
+}

--- a/test.examples/test/resources/META-INF/services/se.jbee.inject.bind.Bundle
+++ b/test.examples/test/resources/META-INF/services/se.jbee.inject.bind.Bundle
@@ -1,2 +1,2 @@
-test.example1.MyRootBundle
-test.example1.MyEnvSetupBundle
+test.ExamplesEnvBundle
+test.ExamplesBundle

--- a/test.integration/test/java/test/integration/bind/TestBasicBundleForBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicBundleForBinds.java
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.Test;
 import se.jbee.inject.Env;
 import se.jbee.inject.Injector;
 import se.jbee.inject.bind.Bundle;
+import se.jbee.inject.bind.Dependent;
 import se.jbee.inject.bind.Module;
-import se.jbee.inject.bind.Toggled;
 import se.jbee.inject.binder.Binder;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
@@ -15,9 +15,9 @@ import se.jbee.inject.bootstrap.Bootstrap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
- * The test demonstrates how to use {@link Toggled} and the {@link BundleFor} to
- * allow different bootstrapping depended on a toggle property set in the {@link
- * Env}.
+ * The test demonstrates how to use {@link Dependent} and the {@link BundleFor}
+ * to allow different bootstrapping depended on a toggle property set in the
+ * {@link Env}.
  * <p>
  * This technique avoids using if-statements in the {@link Bundle}s and {@link
  * Module}s itself to get manageable and predictable sets of configurations that
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  * In this example we use {@link Binder#multibind(Class)}s to show that just one
  * of the bundles has been installed depending on the value we defined {@link
  * Env} for the {@link Machine} which is our toggle property.
+ *
+ * @see TestBasicDependentInstallBinds
  */
 class TestBasicBundleForBinds {
 
@@ -51,9 +53,9 @@ class TestBasicBundleForBinds {
 
 		@Override
 		protected void bootstrap() {
-			install(GenericMachineBundle.class, null);
-			install(LocalhostBundle.class, Machine.LOCALHOST);
-			install(Worker1Bundle.class, Machine.WORKER_1);
+			installDependentOn(null, GenericMachineBundle.class);
+			installDependentOn(Machine.LOCALHOST, LocalhostBundle.class);
+			installDependentOn(Machine.WORKER_1, Worker1Bundle.class);
 		}
 	}
 
@@ -86,18 +88,18 @@ class TestBasicBundleForBinds {
 
 	@Test
 	void bundleOfTheGivenConstGotBootstrappedAndOthersNot() {
-		assertChoiceResolvedToValue(Machine.LOCALHOST, "on-localhost");
-		assertChoiceResolvedToValue(Machine.WORKER_1, "on-worker-1");
+		assertDependentInstall(Machine.LOCALHOST, "on-localhost");
+		assertDependentInstall(Machine.WORKER_1, "on-worker-1");
 	}
 
 	@Test
 	void bundleOfUndefinedConstGotBootstrappedAndOthersNot() {
-		assertChoiceResolvedToValue(null, "on-generic");
+		assertDependentInstall(null, "on-generic");
 	}
 
-	private static void assertChoiceResolvedToValue(Machine actualChoice,
+	private static void assertDependentInstall(Machine actualChoice,
 			String expectedValue) {
-		Env env = Bootstrap.DEFAULT_ENV.withToggled(Machine.class, actualChoice);
+		Env env = Bootstrap.DEFAULT_ENV.withDependent(Machine.class, actualChoice);
 		Injector context = Bootstrap.injector(env,
 				TestBasicBundleForBindsBundle.class);
 		assertArrayEquals(new String[] { expectedValue },

--- a/test.integration/test/java/test/integration/bind/TestBasicConfigurationBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicConfigurationBinds.java
@@ -2,6 +2,7 @@ package test.integration.bind;
 
 import org.junit.jupiter.api.Test;
 import se.jbee.inject.Injector;
+import se.jbee.inject.Source;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
 import se.jbee.inject.config.Config;
@@ -82,5 +83,12 @@ class TestBasicConfigurationBinds {
 	@Test
 	void convertedConfiguration() {
 		assertNotNull(config.value("uuid").as(UUID.class).orElse(null));
+	}
+
+	@Test
+	void sourceOfConfigValueIsAvailable() {
+		Source source = config.value("foo").source();
+		assertNotNull(source);
+		assertSame(TestBasicConfigurationBindsModule.class, source.ident);
 	}
 }

--- a/test.integration/test/java/test/integration/bind/TestBasicDependentInstallBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicDependentInstallBinds.java
@@ -16,15 +16,17 @@ import static test.integration.util.TestUtils.assertEqualSets;
  * associated {@link se.jbee.inject.bind.Bundle}.
  * <p>
  * This can be used as a classic feature toggle that is configured in the {@link
- * Env} using the {@link Env#withToggled(Class, Enum[])} helper method so set
+ * Env} using the {@link Env#withDependent(Class, Enum[])} helper method so set
  * the selected options.
  * <p>
  * Secondly this technique of using {@link Enum}s constant to represent {@link
  * se.jbee.inject.bind.Bundle} classes allows to hide those implementations
  * behind the {@link Enum} that behaves as the API to outside world so it can
  * reference them when installing or uninstalling them.
+ *
+ * @see TestBasicBundleForBinds
  */
-class TestBasicFeatureToggleBinds {
+class TestBasicDependentInstallBinds {
 
 	private enum Text {
 		A, B, C, D, E
@@ -74,11 +76,11 @@ class TestBasicFeatureToggleBinds {
 
 		@Override
 		protected void bootstrap() {
-			install(A.class, Text.A);
-			install(B.class, Text.B);
-			install(C.class, Text.C);
-			install(D.class, Text.D);
-			install(E.class, Text.E);
+			installDependentOn(Text.A, A.class);
+			installDependentOn(Text.B, B.class);
+			installDependentOn(Text.C, C.class);
+			installDependentOn(Text.D, D.class);
+			installDependentOn(Text.E, E.class);
 		}
 	}
 
@@ -92,7 +94,7 @@ class TestBasicFeatureToggleBinds {
 
 	@Test
 	void multipleChoicesArePossible() {
-		Env env = Bootstrap.DEFAULT_ENV.withToggled(Text.class, Text.A, Text.D);
+		Env env = Bootstrap.DEFAULT_ENV.withDependent(Text.class, Text.A, Text.D);
 		Injector injector = Bootstrap.injector(env, RootBundle.class);
 		assertEqualSets(new String[] { "A", "D" },
 				injector.resolve(String[].class));

--- a/test.integration/test/java/test/integration/bind/TestBasicMultiModuleSetupBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestBasicMultiModuleSetupBinds.java
@@ -51,7 +51,7 @@ class TestBasicMultiModuleSetupBinds {
 	@Test
 	void bindingSourceReflectsTheOrigin() {
 		Injector context = Bootstrap.injector(Bootstrap.DEFAULT_ENV //
-						.with(Env.GP_BIND_BINDINGS, true),
+						.with(Env.BIND_BINDINGS, true),
 				TestBasicMultiModuleSetupBindsBundle.class);
 		Binding<?>[] bindings = context.resolve(Binding[].class);
 

--- a/test.integration/test/java/test/integration/bind/TestFeatureEditionFeatureBinds.java
+++ b/test.integration/test/java/test/integration/bind/TestFeatureEditionFeatureBinds.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import se.jbee.inject.Env;
 import se.jbee.inject.Injector;
 import se.jbee.inject.bind.Bootstrapper;
-import se.jbee.inject.bind.Toggled;
+import se.jbee.inject.bind.Dependent;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.binder.BootstrapperBundle;
 import se.jbee.inject.bootstrap.Bootstrap;
@@ -84,13 +84,13 @@ class TestFeatureEditionFeatureBinds {
 
 	@Featured(AnnotatedFeature.BAZ)
 	private enum FeaturedOptionBundle
-			implements Toggled<FeaturedOptionBundle> {
+			implements Dependent<FeaturedOptionBundle> {
 		QUX;
 
 		@Override
 		public void bootstrap(
-				Bootstrapper.ToggledBootstrapper<FeaturedOptionBundle> bootstrapper) {
-			bootstrapper.install(AnotherModule.class, QUX);
+				Bootstrapper.DependentBootstrapper<FeaturedOptionBundle> bootstrapper) {
+			bootstrapper.installDependentOn(QUX, AnotherModule.class);
 		}
 
 	}

--- a/test.integration/test/java/test/integration/bootstrap/TestDefaultEnv.java
+++ b/test.integration/test/java/test/integration/bootstrap/TestDefaultEnv.java
@@ -66,9 +66,9 @@ class TestDefaultEnv {
 	@Test
 	void defaultEnvDefinesDefaultSettings() {
 		Env env = DefaultEnv.bootstrap();
-		assertDefined(env, Env.GP_USE_DEEP_REFLECTION, boolean.class);
-		assertDefined(env, Env.GP_USE_VERIFICATION, boolean.class);
-		assertDefined(env, Env.GP_DEEP_REFLECTION_PACKAGES, Packages.class);
+		assertDefined(env, Env.USE_DEEP_REFLECTION, boolean.class);
+		assertDefined(env, Env.USE_VERIFICATION, boolean.class);
+		assertDefined(env, Env.DEEP_REFLECTION_PACKAGES, Packages.class);
 	}
 
 	private static void assertDefined(Env env, Class<?> property) {

--- a/test.integration/test/java/test/integration/example1/TestCustomAnnotationBinds.java
+++ b/test.integration/test/java/test/integration/example1/TestCustomAnnotationBinds.java
@@ -1,10 +1,12 @@
 package test.integration.example1;
 
 import org.junit.jupiter.api.Test;
+import se.jbee.inject.Env;
 import se.jbee.inject.Injector;
 import se.jbee.inject.bind.ModuleWith;
 import se.jbee.inject.binder.BinderModule;
 import se.jbee.inject.bootstrap.Bootstrap;
+import test.Example;
 import test.example1.Support;
 
 import java.util.ServiceLoader;
@@ -44,7 +46,8 @@ class TestCustomAnnotationBinds {
 	 */
 	@Test
 	void customAnnotationsAddedViaServiceLoader() {
-	   Injector injector = Bootstrap.injector(Bootstrap.env(),
+		Env env = Example.EXAMPLE_1.env();
+		Injector injector = Bootstrap.injector(env,
 				TestCustomAnnotationBindsModule.class);
 		MySupportService service = injector.resolve(MySupportService.class);
 		assertNotNull(service);

--- a/test.integration/test/java/test/integration/example1/TestServiceLoaderBootstrapBinds.java
+++ b/test.integration/test/java/test/integration/example1/TestServiceLoaderBootstrapBinds.java
@@ -6,7 +6,7 @@ import se.jbee.inject.Injector;
 import se.jbee.inject.bind.Bundle;
 import se.jbee.inject.binder.ServiceLoaderBundles;
 import se.jbee.inject.binder.ServiceLoaderEnvBundles;
-import se.jbee.inject.bootstrap.Bootstrap;
+import test.Example;
 
 import java.util.ServiceLoader;
 
@@ -33,10 +33,10 @@ class TestServiceLoaderBootstrapBinds {
 
 	@Test
 	void serviceLoaderCanBeUsedToDeclareModuleRoots() {
-		Injector context = Bootstrap.injector();
+		Injector context = Example.EXAMPLE_1.injector();
 		assertNotNull(context);
 		assertEquals(13, context.resolve(int.class).intValue());
-		assertEquals("test.example1.MyFirstModule",
+		assertEquals("test.example1.Example1Module",
 				context.resolve(String.class));
 	}
 }

--- a/test.integration/test/java/test/integration/example2/TestEnvNamespaceBinds.java
+++ b/test.integration/test/java/test/integration/example2/TestEnvNamespaceBinds.java
@@ -1,0 +1,107 @@
+package test.integration.example2;
+
+import org.junit.jupiter.api.Test;
+import se.jbee.inject.Injector;
+import se.jbee.inject.UnresolvableDependency;
+import se.jbee.inject.binder.Binder;
+import test.Example;
+import test.example2.Bus;
+import test.example2.Car;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This test example shows how {@link se.jbee.inject.binder.LocalEnvModule} can
+ * be used to set strategies like {@link se.jbee.inject.config.ProducesBy} and
+ * {@link se.jbee.inject.config.NamesBy} for a {@link Package} and their
+ * subpackages.
+ * <p>
+ * In this example there is a {@link Car} and a {@link Bus} related package, one
+ * picking up {@link Car}s when using {@link Binder.ScopedBinder#autobind()},
+ * the other picking up {@link Bus}ses. Within the {@link Car} package is a
+ * subpackages with a {@link Car[]} pool override. Last but not least this pool
+ * behaviour is still set in the sub-package of the corporate {@link Car[]}
+ * pool.
+ * <p>
+ * On the concept level this example verifies the general principle of local
+ * name-spaces in the {@link se.jbee.inject.Env} and that the base class {@link
+ * se.jbee.inject.binder.LocalEnvModule} affects the made bindings accordingly.
+ * <p>
+ * The reason this example only uses {@link Binder.ScopedBinder#autobind()} is
+ * that is also should test the {@link se.jbee.inject.config.ProducesBy} and
+ * {@link se.jbee.inject.config.NamesBy} strategies are resolved in the
+ * localised name-space.
+ */
+class TestEnvNamespaceBinds {
+
+	private final Injector context = Example.EXAMPLE_2.injector();
+
+	@Test
+	void inCarPackageCarProvidersAreBound() {
+		assertCarExists("getPetersCar", "Peter");
+		assertCarExists("getPaulsCar", "Paul");
+	}
+
+	@Test
+	void inCarPackageBusProvidersAreNotBound() {
+		assertBusDoesNotExist("busStopAtCarPark");
+	}
+
+	@Test
+	void inBusPackageBusProvidersAreBound() {
+		assertBusExists("toLondon", "London");
+		assertBusExists("toGlasgow", "Glasgow");
+	}
+
+	@Test
+	void inBusPackageCarProvidersAreNotBound() {
+		assertCarDoesNotExist("carOfBusDriver");
+	}
+
+	@Test
+	void inCarPoolPackageCarArrayProvidersAreBound() {
+		Car[] pool = context.resolve("poolCars", Car[].class);
+		assertEquals(2, pool.length);
+		assertEquals("pool1", pool[0].owner);
+		assertEquals("pool2", pool[1].owner);
+	}
+
+	@Test
+	void inCorporateCarPoolPackageCarArrayProvidersAreBound() {
+		Car[] pool = context.resolve("corporatePool", Car[].class);
+		assertEquals(1, pool.length);
+		assertEquals("monopoly1", pool[0].owner);
+	}
+
+	@Test
+	void inCarPoolPackageCarProvidersAreNotBound() {
+		assertCarDoesNotExist("nextPoolCar");
+	}
+
+	@Test
+	void inCarPoolPackageBusProvidersAreNotBound() {
+		assertBusDoesNotExist("stopAtCarPool");
+	}
+
+	private void assertBusDoesNotExist(String name) {
+		assertThrows(UnresolvableDependency.ResourceResolutionFailed.class,
+				() -> context.resolve(name, Bus.class));
+	}
+
+	private void assertCarDoesNotExist(String name) {
+		assertThrows(UnresolvableDependency.ResourceResolutionFailed.class,
+				() -> context.resolve(name, Car.class));
+	}
+
+	private void assertBusExists(String name, String to) {
+		Bus car = context.resolve(name, Bus.class);
+		assertNotNull(car);
+		assertEquals(to, car.to);
+	}
+
+	private void assertCarExists(String name, String owner) {
+		Car car = context.resolve(name, Car.class);
+		assertNotNull(car);
+		assertEquals(owner, car.owner);
+	}
+}


### PR DESCRIPTION
A lot of detail changes to make localised `Env` properties easy to use.
A new base class `LocalEnvModule` was added which is used in a new `ServiceLoader` setup example.
The `ServiceLoader` based examples now get selected via `enum` property so the test stay (mostly) isolated.